### PR TITLE
feat: expose client completed services count

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,16 @@ AI_SERVICE_API_KEY=your_api_key
 # For local development using PostgreSQL
 DATABASE_URL="postgresql://username:password@localhost:5432/gorda_db?schema=public"
 
+# For Docker Compose development:
+# AUTHENTICATION_EMULATOR_HOST=http://emulators:9099
+# DATABASE_EMULATOR_HOST=emulators
+# FIRESTORE_EMULATOR_HOST=emulators:8080
+# STORAGE_EMULATOR_HOST=http://emulators:9199
+# FIREBASE_DATABASE_URL="http://emulators:9000/?ns=gorda-driver-default-rtdb"
+# GORDA_API_FUNCTIONS="http://emulators:5001/gorda-driver/us-central1/api"
+# AI_SERVICE_URL="http://ia:8000"
+# DATABASE_URL="postgresql://root:root@postgres:5432/gorda_db?schema=public"
+
 # For production, use a secure connection string like:
 # DATABASE_URL="postgresql://username:password@your-db-host:5432/gorda_db?schema=public&sslmode=require"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Expose client completed services count through the services API and service creation flow.
+
+### Changed
+
+- Document Docker Compose local environment values in .env.example.
+
 # Release Notes for 2.0.x
 
 ## [2.0.3(2026-04-14)](https://github.com/DevAlexandreCR/gorda-api/compare/2.0.3...2.0.2)

--- a/src/Api/Controllers/Services/ServiceHistoryController.ts
+++ b/src/Api/Controllers/Services/ServiceHistoryController.ts
@@ -1,6 +1,8 @@
 import { Request, Response, Router } from 'express'
+import * as Sentry from '@sentry/node'
 import Container from '../../../Container/Container'
 import { requireAuth } from '../../../Middlewares/Authorization'
+import ChatIdHelper from '../../../Helpers/ChatIdHelper'
 
 const controller = Router()
 
@@ -64,6 +66,42 @@ controller.get('/history', async (req: Request, res: Response) => {
     })
   } catch (error) {
     console.error('Error fetching service history:', error)
+    return res.status(500).json({
+      success: false,
+      message: 'Internal server error',
+      data: {},
+    })
+  }
+})
+
+controller.get('/clients/:clientId/completed-count', async (req: Request, res: Response) => {
+  try {
+    ChatIdHelper.toCanonicalClientId(req.params.clientId)
+    let completedServicesCount = await Container.getServiceHistoryRepository().count({
+      clientId: req.params.clientId,
+      status: 'terminated',
+    })
+    if (completedServicesCount < 0) {
+      Sentry.captureException(
+        new Error(
+          `Unexpected negative count for clientId=${req.params.clientId}: ${completedServicesCount}`
+        )
+      )
+      completedServicesCount = 0
+    }
+    return res.status(200).json({
+      success: true,
+      data: { completedServicesCount },
+    })
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith('toCanonicalClientId:')) {
+      return res.status(400).json({
+        success: false,
+        message: error.message,
+        data: {},
+      })
+    }
+    Sentry.captureException(error)
     return res.status(500).json({
       success: false,
       message: 'Internal server error',

--- a/src/Api/Controllers/Services/__tests__/ServiceHistoryController.spec.ts
+++ b/src/Api/Controllers/Services/__tests__/ServiceHistoryController.spec.ts
@@ -1,0 +1,208 @@
+import http from 'http'
+import express from 'express'
+import type { AddressInfo } from 'net'
+
+// --- Module mocks ---
+// All jest.mock calls are hoisted. Do NOT reference outer variables in factories.
+
+jest.mock('@sentry/node', () => ({
+  captureException: jest.fn(),
+  init: jest.fn(),
+  Handlers: {
+    requestHandler: jest.fn(() => (_req: any, _res: any, next: any) => next()),
+    tracingHandler: jest.fn(() => (_req: any, _res: any, next: any) => next()),
+    errorHandler: jest.fn(() => (_req: any, _res: any, next: any) => next()),
+  },
+}))
+
+jest.mock('@sentry/tracing', () => ({
+  Integrations: { Express: jest.fn() },
+}))
+
+jest.mock('../../../../Middlewares/Authorization', () => ({
+  requireAuth: jest.fn((_req: any, _res: any, next: any) => next()),
+}))
+
+// --- Typed accessors for mocked modules ---
+
+const MockedAuth = jest.requireMock('../../../../Middlewares/Authorization') as {
+  requireAuth: jest.Mock
+}
+
+// --- HTTP helper ---
+
+function get(
+  server: http.Server,
+  path: string,
+  headers: Record<string, string> = {}
+): Promise<{ status: number; body: any }> {
+  return new Promise((resolve, reject) => {
+    const { port } = server.address() as AddressInfo
+    const opts: http.RequestOptions = {
+      hostname: '127.0.0.1',
+      port,
+      path,
+      method: 'GET',
+      headers,
+    }
+    const req = http.request(opts, (res) => {
+      let data = ''
+      res.on('data', (chunk) => {
+        data += chunk
+      })
+      res.on('end', () => {
+        try {
+          resolve({ status: res.statusCode ?? 0, body: JSON.parse(data) })
+        } catch {
+          resolve({ status: res.statusCode ?? 0, body: data })
+        }
+      })
+    })
+    req.on('error', reject)
+    req.end()
+  })
+}
+
+const VALID_AUTH_HEADERS = {
+  authorization: 'Bearer test-api-key',
+  'x-client-platform': 'admin',
+  'x-client-version': '2.0.0',
+}
+
+// --- Server setup + Container spy ---
+// We import the controller after setting mocks. Container is NOT mocked at the
+// module level here. Instead, we spy on Container.getServiceHistoryRepository
+// using jest.spyOn so that we control what the repository returns per-test.
+
+let server: http.Server
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const Container = require('../../../../Container/Container').default
+const mockCount = jest.fn()
+
+beforeAll((done) => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const controller = require('../ServiceHistoryController').default
+  const app = express()
+  app.use(express.json())
+  app.use('/services', controller)
+  server = http.createServer(app)
+  server.listen(0, '127.0.0.1', done)
+})
+
+afterAll((done) => {
+  server.close(done)
+})
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockCount.mockReset()
+  MockedAuth.requireAuth.mockImplementation((_req: any, _res: any, next: any) => next())
+  jest.spyOn(Container, 'getServiceHistoryRepository').mockReturnValue({ count: mockCount })
+})
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
+// --- Tests ---
+
+describe('GET /services/clients/:clientId/completed-count', () => {
+  describe('200: returns terminated-only count for canonical client id', () => {
+    it('returns 200 with completedServicesCount when clientId is a plain digits string', async () => {
+      mockCount.mockResolvedValue(7)
+
+      const { status, body } = await get(
+        server,
+        '/services/clients/573001234567/completed-count',
+        VALID_AUTH_HEADERS
+      )
+
+      expect(status).toBe(200)
+      expect(body.success).toBe(true)
+      expect(body.data.completedServicesCount).toBe(7)
+    })
+  })
+
+  describe('200: accepts provider-suffixed input (@c.us)', () => {
+    it('returns 200 when clientId is "573001234567@c.us" (stripped to canonical form)', async () => {
+      mockCount.mockResolvedValue(3)
+
+      const { status, body } = await get(
+        server,
+        '/services/clients/573001234567%40c.us/completed-count',
+        VALID_AUTH_HEADERS
+      )
+
+      expect(status).toBe(200)
+      expect(body.success).toBe(true)
+      expect(body.data.completedServicesCount).toBe(3)
+    })
+  })
+
+  describe('400: non-canonicalizable input', () => {
+    it('returns 400 with success:false when clientId is "abc"', async () => {
+      const { status, body } = await get(
+        server,
+        '/services/clients/abc/completed-count',
+        VALID_AUTH_HEADERS
+      )
+
+      expect(status).toBe(400)
+      expect(body.success).toBe(false)
+      expect(typeof body.message).toBe('string')
+      expect(body.message).toMatch(/toCanonicalClientId/)
+    })
+  })
+
+  describe('500: repo throws unexpected error', () => {
+    it('returns 500 with success:false when the repository throws', async () => {
+      mockCount.mockRejectedValue(new Error('DB connection lost'))
+
+      const { status, body } = await get(
+        server,
+        '/services/clients/573001234567/completed-count',
+        VALID_AUTH_HEADERS
+      )
+
+      expect(status).toBe(500)
+      expect(body.success).toBe(false)
+    })
+  })
+
+  describe('200: clamps negative count to 0 and reports to Sentry', () => {
+    it('returns 200 with completedServicesCount = 0 and calls Sentry when repo returns a negative value', async () => {
+      mockCount.mockResolvedValue(-5)
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const Sentry = require('@sentry/node')
+      jest.spyOn(Sentry, 'captureException')
+
+      const { status, body } = await get(
+        server,
+        '/services/clients/573001234567/completed-count',
+        VALID_AUTH_HEADERS
+      )
+
+      expect(status).toBe(200)
+      expect(body.success).toBe(true)
+      expect(body.data.completedServicesCount).toBe(0)
+      expect(Sentry.captureException).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('Unauthorized: unauthenticated requests are rejected', () => {
+    it('returns 401 when requireAuth rejects the request', async () => {
+      MockedAuth.requireAuth.mockImplementation((_req: any, res: any) => {
+        res.status(401).json({ success: false, message: 'Unauthorized', data: {} })
+      })
+
+      const { status, body } = await get(
+        server,
+        '/services/clients/573001234567/completed-count'
+        // no auth headers
+      )
+
+      expect(status).toBe(401)
+      expect(body.success).toBe(false)
+    })
+  })
+})

--- a/src/Interfaces/ServiceInterface.ts
+++ b/src/Interfaces/ServiceInterface.ts
@@ -20,4 +20,6 @@ export interface ServiceInterface {
   assigned_by?: string | null
   canceled_by?: string | null
   terminated_by?: string | null
+  // RTDB-only snapshot; not persisted to service_history
+  client_completed_services_count?: number | null
 }

--- a/src/Models/Service.ts
+++ b/src/Models/Service.ts
@@ -18,6 +18,7 @@ export default class Service implements ServiceInterface {
   created_at: number
   comment: string | null
   metadata: Metadata
+  client_completed_services_count?: number | null
 
   static readonly STATUS_PENDING = 'pending'
   static readonly STATUS_IN_PROGRESS = 'in_progress'

--- a/src/Repositories/__tests__/ServiceHistoryRepository.spec.ts
+++ b/src/Repositories/__tests__/ServiceHistoryRepository.spec.ts
@@ -14,6 +14,42 @@ describe('ServiceHistoryRepository filter normalization', () => {
     repository = new ServiceHistoryRepository()
   })
 
+  describe('Case E: count() canonicalizes clientId with leading + and filters by status', () => {
+    it('count({ clientId: "+573001234567@c.us", status: "terminated" }) queries with canonical client_id and only terminated rows', async () => {
+      ;(ServiceHistoryRecord.count as jest.Mock).mockResolvedValue(5)
+
+      const result = await repository.count({
+        clientId: '+573001234567@c.us',
+        status: 'terminated',
+      })
+
+      expect(result).toBe(5)
+      expect(ServiceHistoryRecord.count).toHaveBeenCalledTimes(1)
+
+      const callArg = (ServiceHistoryRecord.count as jest.Mock).mock.calls[0][0]
+      const whereClause = callArg.where
+
+      // When multiple filters are present, buildWhere returns { [Op.and]: [...conditions] }.
+      // Symbol keys are invisible to JSON.stringify, so we must inspect the Op.and array
+      // directly rather than relying on JSON serialization of the top-level object.
+      const { Op } = require('sequelize')
+      const conditions: object[] = whereClause[Op.and] ?? [whereClause]
+
+      const conditionsString = JSON.stringify(conditions, (_key, value) => {
+        if (typeof value === 'symbol') return value.toString()
+        return value
+      })
+
+      // clientId must be canonicalized: + and @c.us stripped, digits only
+      expect(conditionsString).toContain('"client_id":"573001234567"')
+      expect(conditionsString).not.toContain('+573001234567')
+      expect(conditionsString).not.toContain('@c.us')
+
+      // status filter must be present so non-terminated rows are excluded
+      expect(conditionsString).toContain('"status":"terminated"')
+    })
+  })
+
   describe('Case D: clientId filter is canonicalized before querying', () => {
     it('count() strips @c.us suffix from clientId and queries with digits-only client_id', async () => {
       ;(ServiceHistoryRecord.count as jest.Mock).mockResolvedValue(3)

--- a/src/Services/chatBot/MessageStrategy/ResponseContract.ts
+++ b/src/Services/chatBot/MessageStrategy/ResponseContract.ts
@@ -73,6 +73,18 @@ export abstract class ResponseContract {
     service.phone = this.currentClient.phone
     service.name = this.currentClient.name
     if (comment) service.comment = comment
+    const canonicalClientId = service.client_id
+    try {
+      service.client_completed_services_count = await Container.getServiceHistoryRepository().count(
+        {
+          clientId: canonicalClientId,
+          status: 'terminated',
+        }
+      )
+    } catch (error) {
+      service.client_completed_services_count = 0
+      Sentry.captureException(error)
+    }
     const dbService = await ServiceRepository.create(service)
     this.session.service_id = dbService.id
     if (this.session.service_id)

--- a/src/Services/chatBot/MessageStrategy/__tests__/ResponseContract.spec.ts
+++ b/src/Services/chatBot/MessageStrategy/__tests__/ResponseContract.spec.ts
@@ -42,7 +42,11 @@ jest.mock('@sentry/node', () => ({
 }))
 
 jest.mock('../../../../Container/Container', () => ({
-  default: { getPlaceRepository: jest.fn() },
+  __esModule: true,
+  default: {
+    getPlaceRepository: jest.fn(),
+    getServiceHistoryRepository: jest.fn(),
+  },
 }))
 
 import { ResponseContract } from '../ResponseContract'
@@ -50,6 +54,11 @@ import ServiceRepository from '../../../../Repositories/ServiceRepository'
 import { PlaceInterface } from '../../../../Interfaces/PlaceInterface'
 import { WpMessage } from '../../../../Types/WpMessage'
 import { ClientInterface } from '../../../../Interfaces/ClientInterface'
+import * as Sentry from '@sentry/node'
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const MockedContainer = require('../../../../Container/Container').default
+const mockCountFn = jest.fn()
 
 const mockPlace: PlaceInterface = {
   id: 'place-1',
@@ -86,6 +95,7 @@ class ConcreteResponseContract extends ResponseContract {
 describe('ResponseContract.createService', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+    mockCountFn.mockReset()
   })
 
   it('passes client_id as canonical digits-only string to ServiceRepository.create', async () => {
@@ -112,5 +122,66 @@ describe('ResponseContract.createService', () => {
 
     const capturedService = (ServiceRepository.create as jest.Mock).mock.calls[0][0]
     expect(capturedService.client_id).toBe('573001234567')
+  })
+
+  it('persists client_completed_services_count with the value returned by the repo (happy path)', async () => {
+    const mockSession = buildMockSession('573001234567@c.us')
+    const completedCount = 7
+
+    mockCountFn.mockResolvedValue(completedCount)
+    MockedContainer.getServiceHistoryRepository.mockReturnValue({ count: mockCountFn })
+
+    const createdService = {
+      id: 'svc-2',
+      client_id: '573001234567',
+      wp_client_id: 'wp-client-1',
+      phone: '+573001234567',
+      name: 'Test User',
+      start_loc: mockPlace,
+      status: 'pending',
+    }
+    ;(ServiceRepository.create as jest.Mock).mockResolvedValue(createdService)
+
+    const contract = new ConcreteResponseContract(mockSession as any)
+    contract['currentClient'] = mockClient
+
+    await contract.createService(mockPlace)
+
+    expect(ServiceRepository.create).toHaveBeenCalledTimes(1)
+    const capturedService = (ServiceRepository.create as jest.Mock).mock.calls[0][0]
+    expect(capturedService.client_completed_services_count).toBe(completedCount)
+  })
+
+  it('persists client_completed_services_count = 0, still creates service, and calls Sentry.captureException when repo throws', async () => {
+    const mockSession = buildMockSession('573001234567@c.us')
+    const repoError = new Error('DB failure')
+
+    mockCountFn.mockRejectedValue(repoError)
+    MockedContainer.getServiceHistoryRepository.mockReturnValue({ count: mockCountFn })
+
+    const createdService = {
+      id: 'svc-3',
+      client_id: '573001234567',
+      wp_client_id: 'wp-client-1',
+      phone: '+573001234567',
+      name: 'Test User',
+      start_loc: mockPlace,
+      status: 'pending',
+    }
+    ;(ServiceRepository.create as jest.Mock).mockResolvedValue(createdService)
+
+    const sentrySpy = jest.spyOn(Sentry, 'captureException')
+
+    const contract = new ConcreteResponseContract(mockSession as any)
+    contract['currentClient'] = mockClient
+
+    await contract.createService(mockPlace)
+
+    expect(ServiceRepository.create).toHaveBeenCalledTimes(1)
+    const capturedService = (ServiceRepository.create as jest.Mock).mock.calls[0][0]
+    expect(capturedService.client_completed_services_count).toBe(0)
+
+    expect(sentrySpy).toHaveBeenCalledTimes(1)
+    expect(sentrySpy).toHaveBeenCalledWith(repoError)
   })
 })

--- a/src/Services/serviceHistory/ServiceHistoryMigrationService.ts
+++ b/src/Services/serviceHistory/ServiceHistoryMigrationService.ts
@@ -155,25 +155,29 @@ class ServiceHistoryMigrationService {
     await ServiceHistoryRecord.upsert(this.buildHistoryPayload(service))
   }
 
-  private buildHistoryPayload(service: ServiceInterface): ServiceInterface {
+  private buildHistoryPayload(
+    service: ServiceInterface
+  ): Omit<ServiceInterface, 'client_completed_services_count'> {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { client_completed_services_count, ...persist } = service
     return {
-      id: service.id,
-      status: service.status,
-      start_loc: service.start_loc,
-      end_loc: service.end_loc ?? null,
-      phone: service.phone,
-      name: service.name,
-      comment: service.comment ?? null,
-      amount: service.amount ?? null,
-      metadata: service.metadata ?? {},
-      driver_id: service.driver_id ?? null,
-      client_id: ChatIdHelper.toCanonicalClientId(service.client_id),
-      wp_client_id: service.wp_client_id ?? null,
-      created_at: Number(service.created_at),
-      created_by: service.created_by ?? null,
-      assigned_by: service.assigned_by ?? null,
-      canceled_by: service.canceled_by ?? null,
-      terminated_by: service.terminated_by ?? null,
+      id: persist.id,
+      status: persist.status,
+      start_loc: persist.start_loc,
+      end_loc: persist.end_loc ?? null,
+      phone: persist.phone,
+      name: persist.name,
+      comment: persist.comment ?? null,
+      amount: persist.amount ?? null,
+      metadata: persist.metadata ?? {},
+      driver_id: persist.driver_id ?? null,
+      client_id: ChatIdHelper.toCanonicalClientId(persist.client_id),
+      wp_client_id: persist.wp_client_id ?? null,
+      created_at: Number(persist.created_at),
+      created_by: persist.created_by ?? null,
+      assigned_by: persist.assigned_by ?? null,
+      canceled_by: persist.canceled_by ?? null,
+      terminated_by: persist.terminated_by ?? null,
     }
   }
 }

--- a/src/Services/serviceHistory/__tests__/ServiceHistoryMigrationService.spec.ts
+++ b/src/Services/serviceHistory/__tests__/ServiceHistoryMigrationService.spec.ts
@@ -81,4 +81,19 @@ describe('ServiceHistoryMigrationService.upsertHistoryRecord', () => {
       expect(ServiceHistoryRecord.upsert).not.toHaveBeenCalled()
     })
   })
+
+  describe('Case D: strips RTDB-only field client_completed_services_count', () => {
+    it('does NOT include client_completed_services_count in the SQL insert payload', async () => {
+      ;(ServiceHistoryRecord.upsert as jest.Mock).mockResolvedValue([{}, true])
+
+      const input = buildMinimalService({ client_completed_services_count: 12 })
+
+      await service.upsertHistoryRecord(input)
+
+      expect(ServiceHistoryRecord.upsert).toHaveBeenCalledTimes(1)
+
+      const capturedArg = (ServiceHistoryRecord.upsert as jest.Mock).mock.calls[0][0]
+      expect(capturedArg).not.toHaveProperty('client_completed_services_count')
+    })
+  })
 })


### PR DESCRIPTION
## Summary
Expose the client completed services count endpoint, propagate the RTDB-only field through service creation flows, and document Docker Compose local environment values in `.env.example`.

## Testing
- `docker compose exec api sh -lc "npm run test"`
- `docker compose exec api sh -lc "npm run build"`
- `docker compose exec api sh -lc "npm run format:check"`

## Changelog
Updated `CHANGELOG.md` under `Unreleased`.