### PR TITLE
[codex] Extract vehicles table integration for API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add normalized vehicle table migration, roster linking flow, and connect endpoint support for drivers.
+- Add normalized vehicle table migration, roster linking flow, and connect endpoint support for drivers. [#115](https://github.com/DevAlexandreCR/gorda-api/pull/115)
 
 ### Changed
 
-- Tighten vehicle completeness validation and lookup response handling for the extracted vehicles flow.
+- Tighten vehicle completeness validation and lookup response handling for the extracted vehicles flow. [#115](https://github.com/DevAlexandreCR/gorda-api/pull/115)
 
 ## [2.0.4(2026-06-08)](https://github.com/DevAlexandreCR/gorda-api/compare/2.0.4...2.0.3)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.5(2026-06-12)](https://github.com/DevAlexandreCR/gorda-api/compare/2.0.5...2.0.4)
+
+### Added
+
+- Add normalized vehicle table migration, roster linking flow, and connect endpoint support for drivers.
+
+### Changed
+
+- Tighten vehicle completeness validation and lookup response handling for the extracted vehicles flow.
+
 ## [2.0.4(2026-06-08)](https://github.com/DevAlexandreCR/gorda-api/compare/2.0.4...2.0.3)
 
 ### Added

--- a/agents.md
+++ b/agents.md
@@ -25,6 +25,13 @@ This document explains the agents (long-running services, jobs, and helper modul
 - Caches branches, WhatsApp clients, and settings so that the Socket/HTTP layers can read them without repeating DB calls.
 - Emits hydrated data into memory upon app start (`store.getBranches()`, `store.getWpClients()` in `app.ts`).
 - Acts as a central registry for downstream agents needing tenant-level configuration.
+- Exposes `Store.isFeatureEnabled('vehicles.read_from_tables')` — the feature flag that gates reading vehicle data from Postgres tables vs. the legacy JSONB column. The flag is backed by the `settings` table and can be flipped live via `PUT /feature-flags/vehicles.read_from_tables`.
+
+### 1.5 Driver-App Connect/Disconnect (`src/Api/Controllers/DriverAppController.ts`)
+- `POST /driver-app/me/connect` is the single entry point for driver presence. It runs a five-step flow — check driver enabled → check vehicle enabled → check driver-vehicle link selectable → `ActiveVehicleAssignmentRepository.acquire` (SQL) → write `/online_drivers/{id}` to RTDB — all inside a single Sequelize transaction. Direct RTDB presence writes from the Android app are deprecated; the API now owns all writes to `/online_drivers`.
+- `POST /driver-app/me/disconnect` idempotently deletes the assignment row and removes the RTDB presence node.
+- **`ForceDisconnect` service** — internal helper called when an admin disables a vehicle or toggles `selectable=false` on an active link. It deletes the assignment, removes the RTDB node, and sends an FCM data payload `{ type: "force_disconnect", reason }` to the driver via the existing FCM path.
+- **`AutoPromoteVehicle` service** — picks the most recently-linked eligible vehicle (`ORDER BY added_at DESC LIMIT 1`) and updates `drivers.selected_vehicle_id`; sets `NULL` if no eligible link exists. Called on `setSelectable=false` and on `vehicles.enabled=false` for every affected driver.
 
 ## 2. Background Jobs (`src/Jobs`)
 
@@ -52,9 +59,16 @@ This document explains the agents (long-running services, jobs, and helper modul
 ### 4.1 Sequelize Layer (`src/Database`)
 - `sequelize.ts` exports the configured Sequelize instance (PostgreSQL driver). Migration files live under `Database/Migrations` while seeders reflect initial data loads.
 - Models under `/src/Models` adhere to interfaces in `/src/Interfaces`, ensuring that services stay strongly typed.
+- **Vehicle tables** (added in `extract-vehicles-table`):
+  - `vehicles` — master vehicle registry; `plate` has a unique index and is immutable after creation.
+  - `driver_vehicles` — many-to-many join between drivers and vehicles with a per-link `selectable` boolean flag.
+  - `active_vehicle_assignments` — enforces a one-driver-per-vehicle mutex; `vehicle_id` is the PK and `driver_id` has a separate unique constraint, so attempting to acquire an already-held assignment raises a named unique-constraint error that callers inspect to distinguish `vehicle_in_use` from `driver_already_connected`.
 
 ### 4.2 Repositories (`src/Repositories`)
 - Each repository (`ClientRepository`, `PlaceRepository`, etc.) acts as an internal API for queries. Services never hit Sequelize directly; they request data through repositories so that caching, eager-loading, and auditing are centralized.
+- `VehicleRepository` — `findByNormalizedPlate`, `findById`, `create`, `update`, `setEnabled`, `search`, `findWithLinkedDrivers`, and `findOrCreateByPlate` (uses `SELECT … FOR UPDATE` inside a transaction).
+- `DriverVehicleRepository` — `listForDriver`, `link`, `setSelectable`, `findEligibleForDriver`, `findMostRecentEligible`.
+- `ActiveVehicleAssignmentRepository` — `acquire`, `releaseByDriver`, `releaseByVehicle`, `findByDriver`, `findByVehicle`.
 
 ## 5. Notification Agents
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gorda-api",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gorda-api",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "license": "ISC",
       "dependencies": {
         "@hapi/boom": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gorda-api",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "WhatsApp chatbot to gorda admin",
   "main": "src/app.ts",
   "scripts": {

--- a/scripts/audit-vehicles.ts
+++ b/scripts/audit-vehicles.ts
@@ -1,0 +1,97 @@
+import sequelize from '../src/Database/sequelize'
+import { normalizePlate } from '../src/Helpers/PlateHelper'
+import { QueryTypes } from 'sequelize'
+import fs from 'fs'
+import path from 'path'
+
+interface DriverRow {
+  id: string
+  name: string
+  email: string
+}
+
+interface DriverWithVehicle extends DriverRow {
+  vehicle: { plate?: string; brand?: string; model?: string } | null
+}
+
+interface DriverWithPlate extends DriverRow {
+  plate: string
+}
+
+async function main(): Promise<void> {
+  const outputArg = process.argv.indexOf('--output')
+  const outputFile = outputArg !== -1 ? process.argv[outputArg + 1] : null
+
+  // 1. Drivers with empty/null vehicle JSONB
+  const emptyVehicle = (await sequelize.query(
+    `SELECT id, name, email FROM drivers WHERE vehicle IS NULL OR vehicle = '{}'::jsonb OR vehicle = 'null'::jsonb`,
+    { type: QueryTypes.SELECT }
+  )) as DriverRow[]
+
+  // 2. Drivers with malformed vehicle (missing plate, brand, or model)
+  const malformed = (await sequelize.query(
+    `SELECT id, name, email, vehicle FROM drivers
+     WHERE vehicle IS NOT NULL
+       AND vehicle != '{}'::jsonb
+       AND vehicle != 'null'::jsonb
+       AND (
+         vehicle->>'plate' IS NULL OR vehicle->>'plate' = ''
+         OR vehicle->>'brand' IS NULL OR vehicle->>'brand' = ''
+         OR vehicle->>'model' IS NULL OR vehicle->>'model' = ''
+       )`,
+    { type: QueryTypes.SELECT }
+  )) as DriverWithVehicle[]
+
+  // 3. Duplicate normalized plates
+  const allWithPlates = (await sequelize.query(
+    `SELECT id, name, email, vehicle->>'plate' as plate FROM drivers
+     WHERE vehicle->>'plate' IS NOT NULL AND vehicle->>'plate' != ''`,
+    { type: QueryTypes.SELECT }
+  )) as DriverWithPlate[]
+
+  // Group by normalized plate
+  const plateMap = new Map<string, DriverWithPlate[]>()
+  for (const row of allWithPlates) {
+    const normalized = normalizePlate(row.plate)
+    if (!plateMap.has(normalized)) plateMap.set(normalized, [])
+    plateMap.get(normalized)!.push(row)
+  }
+  const duplicates = Array.from(plateMap.entries()).filter(([, rows]) => rows.length > 1)
+
+  // Build CSV
+  const lines: string[] = []
+  lines.push('section,driver_id,name,email,plate,normalized_plate,note')
+
+  for (const row of emptyVehicle) {
+    lines.push(`empty_vehicle,${row.id},"${row.name}","${row.email}",,,"empty or null JSONB"`)
+  }
+
+  for (const row of malformed) {
+    const plate = row.vehicle?.plate ?? ''
+    lines.push(`malformed_vehicle,${row.id},"${row.name}","${row.email}","${plate}",,,"missing required field"`)
+  }
+
+  for (const [normalized, rows] of duplicates) {
+    for (const row of rows) {
+      lines.push(
+        `duplicate_plate,${row.id},"${row.name}","${row.email}","${row.plate}","${normalized}","collides with ${rows.length} drivers"`
+      )
+    }
+  }
+
+  const csv = lines.join('\n')
+
+  if (outputFile) {
+    fs.writeFileSync(path.resolve(outputFile), csv, 'utf8')
+    console.error(`Report written to ${path.resolve(outputFile)}`)
+  } else {
+    console.log(csv)
+  }
+
+  await sequelize.close()
+}
+
+main().catch((e) => {
+  console.error(e)
+  process.exit(1)
+})

--- a/src/Api/Controllers/Drivers/DriverAppController.ts
+++ b/src/Api/Controllers/Drivers/DriverAppController.ts
@@ -1,14 +1,23 @@
 import { Request, Response, Router } from 'express'
+import { UniqueConstraintError } from 'sequelize'
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
 import timezone from 'dayjs/plugin/timezone'
 import Container from '../../../Container/Container'
 import { DriverAuthenticatedRequest, requireDriverAuth } from '../../../Middlewares/Authorization'
+import DriverRecord from '../../../Models/DriverRecord'
+import VehicleRecord from '../../../Models/VehicleRecord'
+import ActiveVehicleAssignmentRecord from '../../../Models/ActiveVehicleAssignmentRecord'
+import ActiveVehicleAssignmentRepository from '../../../Repositories/ActiveVehicleAssignmentRepository'
+import DriverVehicleRepository from '../../../Repositories/DriverVehicleRepository'
+import DatabaseService from '../../../Services/firebase/Database'
+import sequelize from '../../../Database/sequelize'
 
 dayjs.extend(utc)
 dayjs.extend(timezone)
 
 const controller = Router()
+const driverVehicleRepo = new DriverVehicleRepository()
 
 controller.use(requireDriverAuth)
 
@@ -107,6 +116,219 @@ controller.delete('/me/token', async (req: Request, res: Response) => {
       message: 'Internal server error',
       data: {},
     })
+  }
+})
+
+controller.post('/me/connect', async (req: Request, res: Response) => {
+  const { driverUid } = req as DriverAuthenticatedRequest
+
+  if (!driverUid) {
+    return res
+      .status(401)
+      .json({ success: false, message: 'Driver authentication required', data: {} })
+  }
+
+  const { vehicle_id, session_id, location } = req.body
+
+  if (!vehicle_id) {
+    return res.status(400).json({ success: false, message: 'vehicle_id is required', data: {} })
+  }
+
+  // Step 1 — verify driver is enabled
+  const driver = await DriverRecord.findByPk(driverUid)
+  if (!driver) {
+    return res.status(404).json({ success: false, message: 'Driver not found', data: {} })
+  }
+  const driverPlain = driver.get({ plain: true }) as any
+  if (!driverPlain.enabled_at || Number(driverPlain.enabled_at) <= 0) {
+    console.log(JSON.stringify({ metric: 'connect.rejected.driver_disabled', driverId: driverUid }))
+    return res.status(403).json({ error: 'driver_disabled' })
+  }
+
+  // Step 2 — verify vehicle exists and is enabled
+  const vehicle = await VehicleRecord.findByPk(vehicle_id)
+  if (!vehicle) {
+    return res.status(404).json({ success: false, message: 'Vehicle not found', data: {} })
+  }
+  const vehiclePlain = vehicle.get({ plain: true }) as any
+  if (!vehiclePlain.enabled) {
+    console.log(
+      JSON.stringify({
+        metric: 'connect.rejected.vehicle_disabled',
+        driverId: driverUid,
+        vehicleId: vehicle_id,
+      })
+    )
+    return res.status(400).json({ error: 'vehicle_disabled' })
+  }
+
+  // Step 3 — verify driver-vehicle link exists and is selectable
+  const links = await driverVehicleRepo.listForDriver(driverUid, { includeAll: true })
+  const link = links.find((l) => l.vehicle_id === String(vehicle_id))
+  if (!link || !link.selectable) {
+    console.log(
+      JSON.stringify({
+        metric: 'connect.rejected.vehicle_not_selectable',
+        driverId: driverUid,
+        vehicleId: vehicle_id,
+      })
+    )
+    return res.status(400).json({ error: 'vehicle_not_selectable' })
+  }
+
+  // Steps 4 & 5 — insert assignment in a transaction, then write RTDB presence
+  const txn = await sequelize.transaction()
+  try {
+    await ActiveVehicleAssignmentRecord.create(
+      {
+        vehicle_id: String(vehicle_id),
+        driver_id: driverUid,
+        session_id: session_id ? String(session_id) : null,
+      },
+      { transaction: txn }
+    )
+
+    // Step 5 — write RTDB presence before committing
+    try {
+      await DatabaseService.dbConnectedDrivers()
+        .child(driverUid)
+        .set({
+          id: driverUid,
+          vehicle_id: String(vehicle_id),
+          session_id: session_id ? String(session_id) : null,
+          location: location ?? null,
+          last_seen_at: Date.now(),
+        })
+    } catch (rtdbErr) {
+      await txn.rollback()
+      console.error('RTDB write failed during connect:', rtdbErr)
+      return res.status(503).json({ error: 'presence_unavailable' })
+    }
+
+    await txn.commit()
+    console.log(
+      JSON.stringify({ metric: 'connect.success', driverId: driverUid, vehicleId: vehicle_id })
+    )
+    return res.status(200).json({ success: true, data: {} })
+  } catch (err) {
+    await txn.rollback()
+    if (err instanceof UniqueConstraintError) {
+      const constraint = (err as any).parent?.constraint
+      if (constraint === 'active_vehicle_assignments_pkey') {
+        // Vehicle is already held by another driver — find who holds it
+        const heldAssignment = await ActiveVehicleAssignmentRepository.findByVehicle(
+          String(vehicle_id)
+        )
+        let heldBy: { id: string; name: string } | null = null
+        if (heldAssignment) {
+          const holderDriver = await DriverRecord.findByPk(heldAssignment.driver_id)
+          if (holderDriver) {
+            const holderPlain = holderDriver.get({ plain: true }) as any
+            heldBy = { id: holderPlain.id, name: holderPlain.name }
+          }
+        }
+        console.log(
+          JSON.stringify({
+            metric: 'connect.rejected.vehicle_in_use',
+            driverId: driverUid,
+            vehicleId: vehicle_id,
+          })
+        )
+        return res.status(409).json({ error: 'vehicle_in_use', held_by: heldBy })
+      } else if (constraint === 'active_vehicle_assignments_driver_id_key') {
+        console.log(
+          JSON.stringify({
+            metric: 'connect.rejected.driver_already_connected',
+            driverId: driverUid,
+          })
+        )
+        return res.status(409).json({ error: 'driver_already_connected' })
+      }
+    }
+    console.error('Error during driver connect:', err)
+    return res.status(500).json({ success: false, message: 'Internal server error', data: {} })
+  }
+})
+
+controller.post('/me/disconnect', async (req: Request, res: Response) => {
+  const { driverUid } = req as DriverAuthenticatedRequest
+
+  if (!driverUid) {
+    return res
+      .status(401)
+      .json({ success: false, message: 'Driver authentication required', data: {} })
+  }
+
+  try {
+    await ActiveVehicleAssignmentRepository.releaseByDriver(driverUid)
+    await DatabaseService.dbConnectedDrivers().child(driverUid).remove()
+    return res.status(200).json({ success: true, data: {} })
+  } catch (error) {
+    console.error('Error during driver disconnect:', error)
+    return res.status(500).json({ success: false, message: 'Internal server error', data: {} })
+  }
+})
+
+controller.get('/me/vehicles', async (req: Request, res: Response) => {
+  const { driverUid } = req as DriverAuthenticatedRequest
+
+  if (!driverUid) {
+    return res
+      .status(401)
+      .json({ success: false, message: 'Driver authentication required', data: {} })
+  }
+
+  try {
+    const vehicles = await driverVehicleRepo.listForDriver(driverUid, { includeAll: false })
+    const driverRaw = await DriverRecord.findByPk(driverUid)
+    const selectedVehicleId = (driverRaw?.get({ plain: true }) as any)?.selected_vehicle_id ?? null
+    const assignment = await ActiveVehicleAssignmentRepository.findByDriver(driverUid)
+
+    const result = vehicles.map((v) => ({
+      ...v.vehicle,
+      vehicle_id: v.vehicle_id,
+      selectable: v.selectable,
+      is_selected: v.vehicle_id === selectedVehicleId,
+      is_active: assignment?.vehicle_id === v.vehicle_id,
+    }))
+
+    return res.status(200).json({ success: true, data: { vehicles: result } })
+  } catch (error) {
+    console.error('Error fetching driver vehicles:', error)
+    return res.status(500).json({ success: false, message: 'Internal server error', data: {} })
+  }
+})
+
+controller.put('/me/selected-vehicle', async (req: Request, res: Response) => {
+  const { driverUid } = req as DriverAuthenticatedRequest
+
+  if (!driverUid) {
+    return res
+      .status(401)
+      .json({ success: false, message: 'Driver authentication required', data: {} })
+  }
+
+  const { vehicle_id } = req.body
+
+  if (!vehicle_id) {
+    return res.status(400).json({ success: false, message: 'vehicle_id is required', data: {} })
+  }
+
+  try {
+    const eligibleLinks = await driverVehicleRepo.findEligibleForDriver(driverUid)
+    const isEligible = eligibleLinks.some((link) => link.vehicle_id === String(vehicle_id))
+    if (!isEligible) {
+      return res.status(400).json({ error: 'vehicle_not_eligible' })
+    }
+
+    await DriverRecord.update({ selected_vehicle_id: String(vehicle_id) } as any, {
+      where: { id: driverUid },
+    })
+
+    return res.status(200).json({ success: true, data: {} })
+  } catch (error) {
+    console.error('Error updating selected vehicle:', error)
+    return res.status(500).json({ success: false, message: 'Internal server error', data: {} })
   }
 })
 

--- a/src/Api/Controllers/Drivers/DriverAppController.ts
+++ b/src/Api/Controllers/Drivers/DriverAppController.ts
@@ -129,6 +129,8 @@ controller.post('/me/connect', async (req: Request, res: Response) => {
   }
 
   const { vehicle_id, session_id, location } = req.body
+  const requestedVehicleId = String(vehicle_id)
+  const requestedSessionId = session_id ? String(session_id) : null
 
   if (!vehicle_id) {
     return res.status(400).json({ success: false, message: 'vehicle_id is required', data: {} })
@@ -156,7 +158,7 @@ controller.post('/me/connect', async (req: Request, res: Response) => {
       JSON.stringify({
         metric: 'connect.rejected.vehicle_disabled',
         driverId: driverUid,
-        vehicleId: vehicle_id,
+        vehicleId: requestedVehicleId,
       })
     )
     return res.status(400).json({ error: 'vehicle_disabled' })
@@ -170,7 +172,7 @@ controller.post('/me/connect', async (req: Request, res: Response) => {
       JSON.stringify({
         metric: 'connect.rejected.vehicle_not_selectable',
         driverId: driverUid,
-        vehicleId: vehicle_id,
+        vehicleId: requestedVehicleId,
       })
     )
     return res.status(400).json({ error: 'vehicle_not_selectable' })
@@ -179,14 +181,153 @@ controller.post('/me/connect', async (req: Request, res: Response) => {
   // Steps 4 & 5 — insert assignment in a transaction, then write RTDB presence
   const txn = await sequelize.transaction()
   try {
-    await ActiveVehicleAssignmentRecord.create(
-      {
-        vehicle_id: String(vehicle_id),
-        driver_id: driverUid,
-        session_id: session_id ? String(session_id) : null,
-      },
-      { transaction: txn }
-    )
+    const createAssignment = async () =>
+      ActiveVehicleAssignmentRecord.create(
+        {
+          vehicle_id: requestedVehicleId,
+          driver_id: driverUid,
+          session_id: requestedSessionId,
+        },
+        { transaction: txn }
+      )
+
+    const resolveUniqueConstraint = async (err: UniqueConstraintError): Promise<Response | null> => {
+      const constraint = (err as any).parent?.constraint
+
+      if (constraint === 'active_vehicle_assignments_pkey') {
+        const heldRecord = await ActiveVehicleAssignmentRecord.findByPk(requestedVehicleId, {
+          transaction: txn,
+        })
+        const heldAssignment = heldRecord?.get({ plain: true }) as
+          | { vehicle_id: string; driver_id: string; session_id: string | null }
+          | undefined
+
+        if (!heldAssignment || heldAssignment.driver_id !== driverUid) {
+          await txn.rollback()
+
+          let heldBy: { id: string; name: string } | null = null
+          if (heldAssignment) {
+            const holderDriver = await DriverRecord.findByPk(heldAssignment.driver_id)
+            if (holderDriver) {
+              const holderPlain = holderDriver.get({ plain: true }) as any
+              heldBy = { id: holderPlain.id, name: holderPlain.name }
+            }
+          }
+
+          console.log(
+            JSON.stringify({
+              metric: 'connect.rejected.vehicle_in_use',
+              driverId: driverUid,
+              vehicleId: requestedVehicleId,
+              heldByDriverId: heldAssignment?.driver_id ?? null,
+            })
+          )
+          return res.status(409).json({ error: 'vehicle_in_use', held_by: heldBy })
+        }
+
+        await ActiveVehicleAssignmentRecord.update(
+          { session_id: requestedSessionId },
+          {
+            where: {
+              vehicle_id: requestedVehicleId,
+              driver_id: driverUid,
+            },
+            transaction: txn,
+          }
+        )
+
+        console.log(
+          JSON.stringify({
+            metric: 'connect.refreshed_existing_driver_assignment',
+            driverId: driverUid,
+            vehicleId: requestedVehicleId,
+          })
+        )
+        return null
+      }
+
+      if (constraint === 'active_vehicle_assignments_driver_id_key') {
+        const existingRecord = await ActiveVehicleAssignmentRecord.findOne({
+          where: { driver_id: driverUid },
+          transaction: txn,
+        })
+        const existingAssignment = existingRecord?.get({ plain: true }) as
+          | { vehicle_id: string; driver_id: string; session_id: string | null }
+          | undefined
+
+        if (!existingAssignment) {
+          console.log(
+            JSON.stringify({
+              metric: 'connect.rejected.driver_already_connected',
+              driverId: driverUid,
+            })
+          )
+          await txn.rollback()
+          return res.status(409).json({ error: 'driver_already_connected' })
+        }
+
+        if (existingAssignment.vehicle_id === requestedVehicleId) {
+          await ActiveVehicleAssignmentRecord.update(
+            { session_id: requestedSessionId },
+            {
+              where: {
+                vehicle_id: requestedVehicleId,
+                driver_id: driverUid,
+              },
+              transaction: txn,
+            }
+          )
+
+          console.log(
+            JSON.stringify({
+              metric: 'connect.refreshed_existing_driver_assignment',
+              driverId: driverUid,
+              vehicleId: requestedVehicleId,
+            })
+          )
+          return null
+        }
+
+        await ActiveVehicleAssignmentRecord.destroy({
+          where: { driver_id: driverUid },
+          transaction: txn,
+        })
+
+        console.log(
+          JSON.stringify({
+            metric: 'connect.cleaned_stale_driver_assignment',
+            driverId: driverUid,
+            oldVehicleId: existingAssignment.vehicle_id,
+            newVehicleId: requestedVehicleId,
+          })
+        )
+
+        try {
+          await createAssignment()
+          return null
+        } catch (retryErr) {
+          if (!(retryErr instanceof UniqueConstraintError)) {
+            throw retryErr
+          }
+          return resolveUniqueConstraint(retryErr)
+        }
+      }
+
+      throw err
+    }
+
+    try {
+      await createAssignment()
+    } catch (err) {
+      if (!(err instanceof UniqueConstraintError)) {
+        throw err
+      }
+
+      const response = await resolveUniqueConstraint(err)
+      if (response) {
+        return response
+      }
+    }
 
     // Step 5 — write RTDB presence before committing
     try {
@@ -194,9 +335,9 @@ controller.post('/me/connect', async (req: Request, res: Response) => {
         .child(driverUid)
         .set({
           id: driverUid,
-          vehicle_id: String(vehicle_id),
+          vehicle_id: requestedVehicleId,
           vehicle_plate: vehiclePlain.plate,
-          session_id: session_id ? String(session_id) : null,
+          session_id: requestedSessionId,
           location: location ?? null,
           last_seen_at: Date.now(),
         })
@@ -208,44 +349,11 @@ controller.post('/me/connect', async (req: Request, res: Response) => {
 
     await txn.commit()
     console.log(
-      JSON.stringify({ metric: 'connect.success', driverId: driverUid, vehicleId: vehicle_id })
+      JSON.stringify({ metric: 'connect.success', driverId: driverUid, vehicleId: requestedVehicleId })
     )
     return res.status(200).json({ success: true, data: {} })
   } catch (err) {
     await txn.rollback()
-    if (err instanceof UniqueConstraintError) {
-      const constraint = (err as any).parent?.constraint
-      if (constraint === 'active_vehicle_assignments_pkey') {
-        // Vehicle is already held by another driver — find who holds it
-        const heldAssignment = await ActiveVehicleAssignmentRepository.findByVehicle(
-          String(vehicle_id)
-        )
-        let heldBy: { id: string; name: string } | null = null
-        if (heldAssignment) {
-          const holderDriver = await DriverRecord.findByPk(heldAssignment.driver_id)
-          if (holderDriver) {
-            const holderPlain = holderDriver.get({ plain: true }) as any
-            heldBy = { id: holderPlain.id, name: holderPlain.name }
-          }
-        }
-        console.log(
-          JSON.stringify({
-            metric: 'connect.rejected.vehicle_in_use',
-            driverId: driverUid,
-            vehicleId: vehicle_id,
-          })
-        )
-        return res.status(409).json({ error: 'vehicle_in_use', held_by: heldBy })
-      } else if (constraint === 'active_vehicle_assignments_driver_id_key') {
-        console.log(
-          JSON.stringify({
-            metric: 'connect.rejected.driver_already_connected',
-            driverId: driverUid,
-          })
-        )
-        return res.status(409).json({ error: 'driver_already_connected' })
-      }
-    }
     console.error('Error during driver connect:', err)
     return res.status(500).json({ success: false, message: 'Internal server error', data: {} })
   }

--- a/src/Api/Controllers/Drivers/DriverAppController.ts
+++ b/src/Api/Controllers/Drivers/DriverAppController.ts
@@ -195,6 +195,7 @@ controller.post('/me/connect', async (req: Request, res: Response) => {
         .set({
           id: driverUid,
           vehicle_id: String(vehicle_id),
+          vehicle_plate: vehiclePlain.plate,
           session_id: session_id ? String(session_id) : null,
           location: location ?? null,
           last_seen_at: Date.now(),

--- a/src/Api/Controllers/Drivers/DriverAppController.ts
+++ b/src/Api/Controllers/Drivers/DriverAppController.ts
@@ -288,6 +288,7 @@ controller.get('/me/vehicles', async (req: Request, res: Response) => {
       ...v.vehicle,
       vehicle_id: v.vehicle_id,
       selectable: v.selectable,
+      is_selectable: v.selectable,
       is_selected: v.vehicle_id === selectedVehicleId,
       is_active: assignment?.vehicle_id === v.vehicle_id,
     }))

--- a/src/Api/Controllers/Drivers/DriversController.ts
+++ b/src/Api/Controllers/Drivers/DriversController.ts
@@ -7,6 +7,7 @@ import { DriverInterface } from '../../../Interfaces/DriverInterface'
 import { Store } from '../../../Services/store/Store'
 import { DriverListQuery } from '../../../Repositories/DriverRecordRepository'
 import DriverRepository from '../../../Repositories/DriverRepository'
+import { VehicleRecordInterface } from '../../../Interfaces/VehicleRecordInterface'
 import FCM from '../../../Services/firebase/FCM'
 import { FCMNotification } from '../../../Types/FCMNotifications'
 import DriverVehicleRepository from '../../../Repositories/DriverVehicleRepository'
@@ -22,6 +23,37 @@ const publicController = Router()
 const store = Store.getInstance()
 const driverVehicleRepo = new DriverVehicleRepository()
 const vehicleRepo = new VehicleRepository()
+
+type MobileDriverVehicle = Pick<
+  VehicleRecordInterface,
+  'id' | 'plate' | 'brand' | 'model' | 'photoUrl' | 'color' | 'enabled'
+> & {
+  is_selected: boolean
+  is_selectable: boolean
+  is_active: boolean
+}
+
+function toMobileDriverVehicle(
+  vehicle: VehicleRecordInterface,
+  options: {
+    selectedVehicleId: string | null
+    isSelectable: boolean
+    activeVehicleId: string | null
+  }
+): MobileDriverVehicle {
+  return {
+    id: vehicle.id,
+    plate: vehicle.plate,
+    brand: vehicle.brand ?? null,
+    model: vehicle.model ?? null,
+    photoUrl: vehicle.photoUrl ?? null,
+    color: vehicle.color ?? null,
+    enabled: Boolean(vehicle.enabled),
+    is_selected: vehicle.id === options.selectedVehicleId,
+    is_selectable: options.isSelectable && Boolean(vehicle.enabled),
+    is_active: vehicle.id === options.activeVehicleId,
+  }
+}
 
 controller.use(requireAuth)
 
@@ -640,9 +672,43 @@ publicController.get('/:id', async (req: Request, res: Response) => {
       })
     }
 
+    const selectedVehicleId = driver.selected_vehicle_id ?? null
+    const [rosterLinks, activeAssignment] = await Promise.all([
+      driverVehicleRepo.listForDriver(req.params.id, { includeAll: true }),
+      ActiveVehicleAssignmentRepository.findByDriver(req.params.id),
+    ])
+
+    const activeVehicleId = activeAssignment?.vehicle_id ?? null
+    const roster = rosterLinks.map((link) =>
+      toMobileDriverVehicle(link.vehicle, {
+        selectedVehicleId,
+        isSelectable: link.selectable,
+        activeVehicleId,
+      })
+    )
+
+    let selected_vehicle = roster.find((vehicle) => vehicle.id === selectedVehicleId) ?? null
+    if (selectedVehicleId && selected_vehicle === null) {
+      const vehicle = await vehicleRepo.findById(selectedVehicleId)
+      if (vehicle) {
+        selected_vehicle = toMobileDriverVehicle(vehicle, {
+          selectedVehicleId,
+          isSelectable: false,
+          activeVehicleId,
+        })
+      }
+    }
+
     return res.status(200).json({
       success: true,
-      data: { driver },
+      data: {
+        driver: {
+          ...driver,
+          selected_vehicle_id: selectedVehicleId,
+          selected_vehicle,
+          roster,
+        },
+      },
     })
   } catch (error) {
     console.error('Error fetching public driver:', error)

--- a/src/Api/Controllers/Drivers/DriversController.ts
+++ b/src/Api/Controllers/Drivers/DriversController.ts
@@ -255,17 +255,33 @@ controller.post('/:id/vehicles', async (req: Request, res: Response) => {
       }
       if (!brand || typeof brand !== 'string' || String(brand).trim() === '') {
         await txn.rollback()
-        return res.status(400).json({ success: false, message: 'vehicle.brand is required', data: {} })
+        return res
+          .status(400)
+          .json({ success: false, message: 'vehicle.brand is required', data: {} })
       }
       if (!model || typeof model !== 'string' || String(model).trim() === '') {
         await txn.rollback()
-        return res.status(400).json({ success: false, message: 'vehicle.model is required', data: {} })
+        return res
+          .status(400)
+          .json({ success: false, message: 'vehicle.model is required', data: {} })
       }
-      if (!color || typeof color !== 'object' || Array.isArray(color) || typeof color.name !== 'string' || String(color.name).trim() === '') {
+      if (
+        !color ||
+        typeof color !== 'object' ||
+        Array.isArray(color) ||
+        typeof color.name !== 'string' ||
+        String(color.name).trim() === ''
+      ) {
         await txn.rollback()
-        return res.status(400).json({ success: false, message: 'vehicle.color is required', data: {} })
+        return res
+          .status(400)
+          .json({ success: false, message: 'vehicle.color is required', data: {} })
       }
-      const created = await vehicleRepo.findOrCreateByPlate(plate, { plate, brand, model, color, ...rest }, txn)
+      const created = await vehicleRepo.findOrCreateByPlate(
+        plate,
+        { plate, brand, model, color, ...rest },
+        txn
+      )
       resolvedVehicleId = created.id as string
     }
 

--- a/src/Api/Controllers/Drivers/DriversController.ts
+++ b/src/Api/Controllers/Drivers/DriversController.ts
@@ -420,6 +420,68 @@ controller.post('/:id/selected-vehicle', async (req: Request, res: Response) => 
   }
 })
 
+controller.post('/:id/recharges', async (req: Request, res: Response) => {
+  const driverId = req.params.id
+  const { amount, created_by, note } = req.body
+
+  if (typeof amount !== 'number' || amount === 0) {
+    return res.status(400).json({
+      success: false,
+      message: 'amount must be a non-zero number',
+      data: {},
+    })
+  }
+
+  if (
+    !created_by ||
+    typeof created_by.uid !== 'string' ||
+    !created_by.uid ||
+    typeof created_by.name !== 'string' ||
+    !created_by.name
+  ) {
+    return res.status(400).json({
+      success: false,
+      message: 'created_by.uid and created_by.name are required',
+      data: {},
+    })
+  }
+
+  try {
+    const { recharge, driver } = await Container.getRechargeRepository().create({
+      driverId,
+      amount,
+      createdBy: { uid: created_by.uid, name: created_by.name },
+      note: note ?? null,
+    })
+    await store.refreshDrivers()
+    return res.status(201).json({ success: true, data: { recharge, driver } })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Internal server error'
+    if (message === 'Driver not found') {
+      return res.status(404).json({ success: false, message, data: {} })
+    }
+    console.error('Error creating recharge:', error)
+    return res.status(500).json({ success: false, message: 'Internal server error', data: {} })
+  }
+})
+
+controller.get('/:id/recharges', async (req: Request, res: Response) => {
+  const driverId = req.params.id
+  const page = parseInt(String(req.query.page ?? '1'), 10) || 1
+  const perPage = parseInt(String(req.query.perPage ?? '20'), 10) || 20
+
+  try {
+    const { rows, total } = await Container.getRechargeRepository().listForDriver(driverId, {
+      page,
+      perPage,
+    })
+    return res.status(200).json({ success: true, data: { recharges: rows, total } })
+  } catch (error) {
+    console.error('Error fetching recharges:', error)
+    return res.status(500).json({ success: false, message: 'Internal server error', data: {} })
+  }
+})
+
 controller.get('/:id', async (req: Request, res: Response) => {
   try {
     const driverId = req.params.id

--- a/src/Api/Controllers/Drivers/DriversController.ts
+++ b/src/Api/Controllers/Drivers/DriversController.ts
@@ -1,4 +1,5 @@
 import { Request, Response, Router } from 'express'
+import { UniqueConstraintError } from 'sequelize'
 import dayjs from 'dayjs'
 import Container from '../../../Container/Container'
 import { requireAuth } from '../../../Middlewares/Authorization'
@@ -8,10 +9,19 @@ import { DriverListQuery } from '../../../Repositories/DriverRecordRepository'
 import DriverRepository from '../../../Repositories/DriverRepository'
 import FCM from '../../../Services/firebase/FCM'
 import { FCMNotification } from '../../../Types/FCMNotifications'
+import DriverVehicleRepository from '../../../Repositories/DriverVehicleRepository'
+import VehicleRepository from '../../../Repositories/VehicleRepository'
+import ActiveVehicleAssignmentRepository from '../../../Repositories/ActiveVehicleAssignmentRepository'
+import DriverRecord from '../../../Models/DriverRecord'
+import sequelize from '../../../Database/sequelize'
+import { autoPromoteSelectedVehicle } from '../../../Services/drivers/AutoPromoteVehicle'
+import { forceDisconnect } from '../../../Services/drivers/ForceDisconnect'
 
 const controller = Router()
 const publicController = Router()
 const store = Store.getInstance()
+const driverVehicleRepo = new DriverVehicleRepository()
+const vehicleRepo = new VehicleRepository()
 
 controller.use(requireAuth)
 
@@ -185,9 +195,187 @@ controller.post('/bulk/send-message', async (req: Request, res: Response) => {
   return res.status(200).json({ success: true, data: { processed, failed } })
 })
 
+// GET /:id/vehicles — list all linked vehicles for a driver
+controller.get('/:id/vehicles', async (req: Request, res: Response) => {
+  try {
+    const driverId = req.params.id
+    const driver = await Container.getDriverRecordRepository().findById(driverId)
+    if (!driver) {
+      return res.status(404).json({ success: false, message: 'Driver not found', data: {} })
+    }
+
+    const links = await driverVehicleRepo.listForDriver(driverId, { includeAll: true })
+    const activeAssignment = await ActiveVehicleAssignmentRepository.findByDriver(driverId)
+    const driverRaw = await DriverRecord.findByPk(driverId)
+    const selectedVehicleId = (driverRaw?.get({ plain: true }) as any)?.selected_vehicle_id ?? null
+
+    const vehicles = links.map((link) => ({
+      ...link,
+      is_selected: link.vehicle_id === selectedVehicleId,
+      is_active: activeAssignment !== null && activeAssignment.vehicle_id === link.vehicle_id,
+    }))
+
+    return res.status(200).json({ success: true, data: { vehicles } })
+  } catch (error) {
+    console.error('Error fetching driver vehicles:', error)
+    return res.status(500).json({ success: false, message: 'Internal server error', data: {} })
+  }
+})
+
+// POST /:id/vehicles — link a vehicle to a driver (by vehicleId or by vehicle payload)
+controller.post('/:id/vehicles', async (req: Request, res: Response) => {
+  const driverId = req.params.id
+  const { vehicleId, vehicle: vehiclePayload } = req.body
+
+  if (!vehicleId && !vehiclePayload) {
+    return res
+      .status(400)
+      .json({ success: false, message: 'vehicleId or vehicle payload required', data: {} })
+  }
+
+  const txn = await sequelize.transaction()
+  try {
+    const driver = await Container.getDriverRecordRepository().findById(driverId)
+    if (!driver) {
+      await txn.rollback()
+      return res.status(404).json({ success: false, message: 'Driver not found', data: {} })
+    }
+
+    let resolvedVehicleId: string
+
+    if (vehicleId) {
+      resolvedVehicleId = String(vehicleId)
+    } else {
+      const { plate, brand, model, color, ...rest } = vehiclePayload
+      if (!plate) {
+        await txn.rollback()
+        return res
+          .status(400)
+          .json({ success: false, message: 'vehicle.plate is required', data: {} })
+      }
+      if (!brand || typeof brand !== 'string' || String(brand).trim() === '') {
+        await txn.rollback()
+        return res.status(400).json({ success: false, message: 'vehicle.brand is required', data: {} })
+      }
+      if (!model || typeof model !== 'string' || String(model).trim() === '') {
+        await txn.rollback()
+        return res.status(400).json({ success: false, message: 'vehicle.model is required', data: {} })
+      }
+      if (!color || typeof color !== 'object' || Array.isArray(color) || typeof color.name !== 'string' || String(color.name).trim() === '') {
+        await txn.rollback()
+        return res.status(400).json({ success: false, message: 'vehicle.color is required', data: {} })
+      }
+      const created = await vehicleRepo.findOrCreateByPlate(plate, { plate, brand, model, color, ...rest }, txn)
+      resolvedVehicleId = created.id as string
+    }
+
+    await driverVehicleRepo.link(driverId, resolvedVehicleId, txn)
+
+    const driverRaw = await DriverRecord.findByPk(driverId, { transaction: txn })
+    const currentSelected = (driverRaw?.get({ plain: true }) as any)?.selected_vehicle_id ?? null
+    if (currentSelected === null) {
+      await DriverRecord.update({ selected_vehicle_id: resolvedVehicleId } as any, {
+        where: { id: driverId },
+        transaction: txn,
+      })
+    }
+
+    await txn.commit()
+    return res.status(201).json({ success: true, data: { vehicle_id: resolvedVehicleId } })
+  } catch (error) {
+    await txn.rollback()
+    if (error instanceof UniqueConstraintError) {
+      return res.status(409).json({ error: 'link_already_exists' })
+    }
+    console.error('Error linking vehicle to driver:', error)
+    return res.status(500).json({ success: false, message: 'Internal server error', data: {} })
+  }
+})
+
+// PATCH /:id/vehicles/:vehicleId — update selectable flag for a driver-vehicle link
+controller.patch('/:id/vehicles/:vehicleId', async (req: Request, res: Response) => {
+  const driverId = req.params.id
+  const vehicleId = req.params.vehicleId
+  const { selectable, confirmed } = req.body
+
+  if (typeof selectable !== 'boolean') {
+    return res
+      .status(400)
+      .json({ success: false, message: 'selectable must be a boolean', data: {} })
+  }
+
+  try {
+    const driver = await Container.getDriverRecordRepository().findById(driverId)
+    if (!driver) {
+      return res.status(404).json({ success: false, message: 'Driver not found', data: {} })
+    }
+
+    if (!selectable) {
+      const assignment = await ActiveVehicleAssignmentRepository.findByDriver(driverId)
+      if (assignment && assignment.vehicle_id === vehicleId) {
+        if (confirmed !== true) {
+          return res.status(409).json({
+            error: 'vehicle_active',
+            held_by: { id: driverId, name: (driver as any).name ?? '' },
+          })
+        }
+        await forceDisconnect(driverId, 'vehicle_not_selectable')
+      }
+    }
+
+    await driverVehicleRepo.setSelectable(driverId, vehicleId, selectable)
+
+    if (!selectable) {
+      const driverRaw = await DriverRecord.findByPk(driverId)
+      const currentSelected = (driverRaw?.get({ plain: true }) as any)?.selected_vehicle_id ?? null
+      if (currentSelected === vehicleId) {
+        await autoPromoteSelectedVehicle(driverId)
+      }
+    }
+
+    return res.status(200).json({ success: true })
+  } catch (error) {
+    console.error('Error updating vehicle selectable:', error)
+    return res.status(500).json({ success: false, message: 'Internal server error', data: {} })
+  }
+})
+
+// POST /:id/selected-vehicle — set the driver's selected vehicle
+controller.post('/:id/selected-vehicle', async (req: Request, res: Response) => {
+  const driverId = req.params.id
+  const { vehicleId } = req.body
+
+  if (!vehicleId) {
+    return res.status(400).json({ success: false, message: 'vehicleId is required', data: {} })
+  }
+
+  try {
+    const driver = await Container.getDriverRecordRepository().findById(driverId)
+    if (!driver) {
+      return res.status(404).json({ success: false, message: 'Driver not found', data: {} })
+    }
+
+    const eligibleLinks = await driverVehicleRepo.findEligibleForDriver(driverId)
+    const isEligible = eligibleLinks.some((link) => link.vehicle_id === String(vehicleId))
+    if (!isEligible) {
+      return res.status(400).json({ error: 'vehicle_not_eligible' })
+    }
+
+    await DriverRecord.update({ selected_vehicle_id: String(vehicleId) } as any, {
+      where: { id: driverId },
+    })
+
+    return res.status(200).json({ success: true })
+  } catch (error) {
+    console.error('Error setting selected vehicle:', error)
+    return res.status(500).json({ success: false, message: 'Internal server error', data: {} })
+  }
+})
+
 controller.get('/:id', async (req: Request, res: Response) => {
   try {
-    const driver = await Container.getDriverRecordRepository().findById(req.params.id)
+    const driverId = req.params.id
+    const driver = await Container.getDriverRecordRepository().findById(driverId)
     if (!driver) {
       return res.status(404).json({
         success: false,
@@ -196,9 +384,32 @@ controller.get('/:id', async (req: Request, res: Response) => {
       })
     }
 
+    // Build enriched response: omit legacy `vehicle` JSONB field, add roster and selected_vehicle
+    const { vehicle: _vehicle, ...driverData } = driver as any
+
+    const [roster, activeAssignment] = await Promise.all([
+      driverVehicleRepo.listForDriver(driverId, { includeAll: true }),
+      ActiveVehicleAssignmentRepository.findByDriver(driverId),
+    ])
+
+    let selected_vehicle = null
+    const selectedVehicleId = (driverData as any).selected_vehicle_id ?? null
+    if (selectedVehicleId) {
+      selected_vehicle = await vehicleRepo.findById(selectedVehicleId)
+    }
+
+    const active_vehicle_id = activeAssignment?.vehicle_id ?? null
+
     return res.status(200).json({
       success: true,
-      data: { driver },
+      data: {
+        driver: {
+          ...driverData,
+          selected_vehicle,
+          roster,
+          active_vehicle_id,
+        },
+      },
     })
   } catch (error) {
     console.error('Error fetching driver:', error)
@@ -212,7 +423,33 @@ controller.get('/:id', async (req: Request, res: Response) => {
 
 controller.post('/', async (req: Request, res: Response) => {
   try {
-    const driver = await Container.getDriverRecordRepository().store(req.body as DriverInterface)
+    const isLegacy = !req.body.driver
+    if (isLegacy) {
+      console.warn('[DEPRECATED] POST /drivers: legacy inline driver shape received')
+    }
+
+    const driverPayload: DriverInterface = isLegacy ? req.body : req.body.driver
+    const vehiclePayload = isLegacy ? req.body.vehicle : req.body.vehicle
+
+    const driver = await Container.getDriverRecordRepository().store(driverPayload)
+
+    if (vehiclePayload) {
+      let resolvedVehicleId: string | undefined
+      if (vehiclePayload.vehicleId) {
+        resolvedVehicleId = String(vehiclePayload.vehicleId)
+      } else if (vehiclePayload.plate) {
+        const vehicle = await vehicleRepo.findOrCreateByPlate(vehiclePayload.plate, vehiclePayload)
+        resolvedVehicleId = vehicle.id as string
+      }
+
+      if (resolvedVehicleId) {
+        await driverVehicleRepo.link(driver.id!, resolvedVehicleId)
+        await DriverRecord.update({ selected_vehicle_id: resolvedVehicleId } as any, {
+          where: { id: driver.id, selected_vehicle_id: null } as any,
+        })
+      }
+    }
+
     await store.refreshDrivers()
 
     return res.status(201).json({
@@ -231,8 +468,17 @@ controller.post('/', async (req: Request, res: Response) => {
 
 controller.put('/:id', async (req: Request, res: Response) => {
   try {
+    const isLegacy = !req.body.driver
+    if (isLegacy) {
+      console.warn('[DEPRECATED] PUT /drivers/:id: legacy inline driver shape received')
+    }
+
+    const rawPayload = isLegacy ? req.body : req.body.driver
+    // Strip vehicle field — vehicle updates must go through /vehicles/:id and /drivers/:id/vehicles
+    const { vehicle: _vehicle, ...driverFields } = rawPayload
+
     const driver = await Container.getDriverRecordRepository().store({
-      ...(req.body as DriverInterface),
+      ...(driverFields as DriverInterface),
       id: req.params.id,
     })
     await store.refreshDrivers()

--- a/src/Api/Controllers/Drivers/DriversController.ts
+++ b/src/Api/Controllers/Drivers/DriversController.ts
@@ -24,7 +24,10 @@ controller.get('/', async (req: Request, res: Response) => {
   if (!hasListedParams) {
     try {
       const drivers = await Container.getDriverRecordRepository().index()
-      return res.status(200).json({ drivers, total: drivers.length })
+      return res.status(200).json({
+        success: true,
+        data: { drivers, total: drivers.length },
+      })
     } catch (error) {
       console.error('Error fetching drivers:', error)
       return res.status(500).json({

--- a/src/Api/Controllers/Drivers/__tests__/DriverAppController.spec.ts
+++ b/src/Api/Controllers/Drivers/__tests__/DriverAppController.spec.ts
@@ -50,10 +50,18 @@ jest.mock('../../../../Models/VehicleRecord', () => ({
 
 // ActiveVehicleAssignmentRecord — Sequelize Model used directly in DriverAppController
 const mockActiveVehicleAssignmentCreate = jest.fn()
+const mockActiveVehicleAssignmentDestroy = jest.fn()
+const mockActiveVehicleAssignmentUpdate = jest.fn()
+const mockActiveVehicleAssignmentFindByPk = jest.fn()
+const mockActiveVehicleAssignmentFindOne = jest.fn()
 jest.mock('../../../../Models/ActiveVehicleAssignmentRecord', () => ({
   __esModule: true,
   default: {
     create: mockActiveVehicleAssignmentCreate,
+    destroy: mockActiveVehicleAssignmentDestroy,
+    update: mockActiveVehicleAssignmentUpdate,
+    findByPk: mockActiveVehicleAssignmentFindByPk,
+    findOne: mockActiveVehicleAssignmentFindOne,
   },
 }))
 
@@ -277,6 +285,10 @@ beforeEach(() => {
   mockRtdbChildRemove.mockResolvedValue(undefined)
   mockDriverRecordUpdate.mockReset()
   mockActiveVehicleAssignmentFindByDriver.mockReset()
+  mockActiveVehicleAssignmentDestroy.mockReset()
+  mockActiveVehicleAssignmentUpdate.mockReset()
+  mockActiveVehicleAssignmentFindByPk.mockReset()
+  mockActiveVehicleAssignmentFindOne.mockReset()
 })
 
 afterEach(() => {
@@ -289,6 +301,7 @@ afterEach(() => {
 
 const DRIVER_UID = 'test-driver-uid'
 const VEHICLE_ID = 'veh-uuid-123'
+const OLD_VEHICLE_ID = 'veh-uuid-old'
 
 function makeEnabledDriver(overrides: Record<string, any> = {}) {
   return {
@@ -312,6 +325,18 @@ function makeLink(overrides: Record<string, any> = {}) {
     vehicle_id: VEHICLE_ID,
     selectable: true,
     ...overrides,
+  }
+}
+
+function makeActiveAssignment(overrides: Record<string, any> = {}) {
+  return {
+    get: (_opts: any) => ({
+      vehicle_id: VEHICLE_ID,
+      driver_id: DRIVER_UID,
+      session_id: null,
+      acquired_at: new Date(),
+      ...overrides,
+    }),
   }
 }
 
@@ -405,13 +430,12 @@ describe('POST /driver-app/me/connect (DriverAppController)', () => {
       ;(pkError as any).parent = { constraint: 'active_vehicle_assignments_pkey' }
       mockActiveVehicleAssignmentCreate.mockRejectedValue(pkError)
 
-      // The repository is asked who holds the vehicle
-      mockActiveVehicleAssignmentFindByVehicle.mockResolvedValue({
-        vehicle_id: VEHICLE_ID,
-        driver_id: holderDriverId,
-        session_id: null,
-        acquired_at: new Date(),
-      })
+      mockActiveVehicleAssignmentFindByPk.mockResolvedValue(
+        makeActiveAssignment({
+          vehicle_id: VEHICLE_ID,
+          driver_id: holderDriverId,
+        })
+      )
 
       const { status, body } = await post(server, '/driver-app/me/connect', {
         vehicle_id: VEHICLE_ID,
@@ -432,7 +456,7 @@ describe('POST /driver-app/me/connect (DriverAppController)', () => {
       const pkError = new UniqueConstraintError({ errors: [] })
       ;(pkError as any).parent = { constraint: 'active_vehicle_assignments_pkey' }
       mockActiveVehicleAssignmentCreate.mockRejectedValue(pkError)
-      mockActiveVehicleAssignmentFindByVehicle.mockResolvedValue(null)
+      mockActiveVehicleAssignmentFindByPk.mockResolvedValue(null)
 
       const { status, body } = await post(server, '/driver-app/me/connect', {
         vehicle_id: VEHICLE_ID,
@@ -444,25 +468,95 @@ describe('POST /driver-app/me/connect (DriverAppController)', () => {
     })
   })
 
-  describe('409: driver_already_connected', () => {
-    it('returns 409 with error=driver_already_connected when driver_id unique constraint fires', async () => {
+  describe('200: self-healed assignment', () => {
+    it('replaces a stale assignment owned by the same driver on another vehicle', async () => {
       mockDriverRecordFindByPk.mockResolvedValue(makeEnabledDriver())
       mockVehicleRecordFindByPk.mockResolvedValue(makeEnabledVehicle())
       mockDriverVehicleListForDriver.mockResolvedValue([makeLink()])
 
-      // Simulate unique constraint on driver_id column
       const driverError = new UniqueConstraintError({ errors: [] })
       ;(driverError as any).parent = { constraint: 'active_vehicle_assignments_driver_id_key' }
-      mockActiveVehicleAssignmentCreate.mockRejectedValue(driverError)
+      mockActiveVehicleAssignmentCreate.mockRejectedValueOnce(driverError).mockResolvedValueOnce({})
+      mockActiveVehicleAssignmentFindOne.mockResolvedValue(
+        makeActiveAssignment({
+          vehicle_id: OLD_VEHICLE_ID,
+          driver_id: DRIVER_UID,
+          session_id: 'stale-session',
+        })
+      )
+      mockActiveVehicleAssignmentDestroy.mockResolvedValue(1)
+      mockRtdbChildSet.mockResolvedValue(undefined)
 
       const { status, body } = await post(server, '/driver-app/me/connect', {
         vehicle_id: VEHICLE_ID,
+        session_id: 'sess-next',
       })
 
-      expect(status).toBe(409)
-      expect(body.error).toBe('driver_already_connected')
-      expect(mockTransactionRollback).toHaveBeenCalledTimes(1)
-      expect(mockRtdbChildSet).not.toHaveBeenCalled()
+      expect(status).toBe(200)
+      expect(body.success).toBe(true)
+      expect(mockActiveVehicleAssignmentCreate).toHaveBeenCalledTimes(2)
+      expect(mockActiveVehicleAssignmentDestroy).toHaveBeenCalledWith({
+        where: { driver_id: DRIVER_UID },
+        transaction: mockTransaction,
+      })
+      expect(mockRtdbChildSet).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: DRIVER_UID,
+          vehicle_id: VEHICLE_ID,
+          vehicle_plate: 'ABC123',
+          session_id: 'sess-next',
+        })
+      )
+      expect(mockTransactionCommit).toHaveBeenCalledTimes(1)
+      expect(mockTransactionRollback).not.toHaveBeenCalled()
+    })
+
+    it('treats reconnecting to the same vehicle as idempotent and refreshes the session', async () => {
+      mockDriverRecordFindByPk.mockResolvedValue(makeEnabledDriver())
+      mockVehicleRecordFindByPk.mockResolvedValue(makeEnabledVehicle())
+      mockDriverVehicleListForDriver.mockResolvedValue([makeLink()])
+
+      const pkError = new UniqueConstraintError({ errors: [] })
+      ;(pkError as any).parent = { constraint: 'active_vehicle_assignments_pkey' }
+      mockActiveVehicleAssignmentCreate.mockRejectedValueOnce(pkError)
+      mockActiveVehicleAssignmentFindByPk.mockResolvedValue(
+        makeActiveAssignment({
+          vehicle_id: VEHICLE_ID,
+          driver_id: DRIVER_UID,
+          session_id: 'old-session',
+        })
+      )
+      mockActiveVehicleAssignmentUpdate.mockResolvedValue([1])
+      mockRtdbChildSet.mockResolvedValue(undefined)
+
+      const { status, body } = await post(server, '/driver-app/me/connect', {
+        vehicle_id: VEHICLE_ID,
+        session_id: 'sess-refresh',
+      })
+
+      expect(status).toBe(200)
+      expect(body.success).toBe(true)
+      expect(mockActiveVehicleAssignmentUpdate).toHaveBeenCalledWith(
+        { session_id: 'sess-refresh' },
+        {
+          where: {
+            vehicle_id: VEHICLE_ID,
+            driver_id: DRIVER_UID,
+          },
+          transaction: mockTransaction,
+        }
+      )
+      expect(mockActiveVehicleAssignmentDestroy).not.toHaveBeenCalled()
+      expect(mockRtdbChildSet).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: DRIVER_UID,
+          vehicle_id: VEHICLE_ID,
+          vehicle_plate: 'ABC123',
+          session_id: 'sess-refresh',
+        })
+      )
+      expect(mockTransactionCommit).toHaveBeenCalledTimes(1)
+      expect(mockTransactionRollback).not.toHaveBeenCalled()
     })
   })
 

--- a/src/Api/Controllers/Drivers/__tests__/DriverAppController.spec.ts
+++ b/src/Api/Controllers/Drivers/__tests__/DriverAppController.spec.ts
@@ -1,0 +1,448 @@
+import http from 'http'
+import express from 'express'
+import type { AddressInfo } from 'net'
+import { UniqueConstraintError } from 'sequelize'
+
+// --- Module mocks (hoisted) ---
+
+jest.mock('@sentry/node', () => ({
+  captureException: jest.fn(),
+  init: jest.fn(),
+  Handlers: {
+    requestHandler: jest.fn(() => (_req: any, _res: any, next: any) => next()),
+    tracingHandler: jest.fn(() => (_req: any, _res: any, next: any) => next()),
+    errorHandler: jest.fn(() => (_req: any, _res: any, next: any) => next()),
+  },
+}))
+
+jest.mock('@sentry/tracing', () => ({
+  Integrations: { Express: jest.fn() },
+}))
+
+// requireDriverAuth — passthrough that injects a fixed driverUid
+jest.mock('../../../../Middlewares/Authorization', () => ({
+  requireDriverAuth: jest.fn((_req: any, _res: any, next: any) => {
+    _req.driverUid = 'test-driver-uid'
+    next()
+  }),
+}))
+
+// DriverRecord — Sequelize Model used directly in DriverAppController
+const mockDriverRecordFindByPk = jest.fn()
+jest.mock('../../../../Models/DriverRecord', () => ({
+  __esModule: true,
+  default: {
+    findByPk: mockDriverRecordFindByPk,
+    update: jest.fn(),
+  },
+  setupDriverAssociations: jest.fn(),
+}))
+
+// VehicleRecord — Sequelize Model used directly in DriverAppController
+const mockVehicleRecordFindByPk = jest.fn()
+jest.mock('../../../../Models/VehicleRecord', () => ({
+  __esModule: true,
+  default: {
+    findByPk: mockVehicleRecordFindByPk,
+  },
+}))
+
+// ActiveVehicleAssignmentRecord — Sequelize Model used directly in DriverAppController
+const mockActiveVehicleAssignmentCreate = jest.fn()
+jest.mock('../../../../Models/ActiveVehicleAssignmentRecord', () => ({
+  __esModule: true,
+  default: {
+    create: mockActiveVehicleAssignmentCreate,
+  },
+}))
+
+// ActiveVehicleAssignmentRepository — singleton default export
+const mockActiveVehicleAssignmentFindByVehicle = jest.fn()
+const mockActiveVehicleAssignmentReleaseByDriver = jest.fn()
+jest.mock('../../../../Repositories/ActiveVehicleAssignmentRepository', () => ({
+  __esModule: true,
+  default: {
+    findByVehicle: mockActiveVehicleAssignmentFindByVehicle,
+    findByDriver: jest.fn(),
+    releaseByDriver: mockActiveVehicleAssignmentReleaseByDriver,
+    releaseByVehicle: jest.fn(),
+    acquire: jest.fn(),
+  },
+}))
+
+// DriverVehicleRepository — class instantiated at module-level in DriverAppController
+const mockDriverVehicleListForDriver = jest.fn()
+const mockDriverVehicleFindEligibleForDriver = jest.fn()
+jest.mock('../../../../Repositories/DriverVehicleRepository', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({
+    listForDriver: mockDriverVehicleListForDriver,
+    link: jest.fn(),
+    setSelectable: jest.fn(),
+    findEligibleForDriver: mockDriverVehicleFindEligibleForDriver,
+    findMostRecentEligible: jest.fn(),
+  })),
+}))
+
+// DatabaseService — firebase RTDB singleton
+const mockRtdbChildSet = jest.fn()
+const mockRtdbChildRemove = jest.fn()
+const mockRtdbChild = jest.fn(() => ({
+  set: mockRtdbChildSet,
+  remove: mockRtdbChildRemove,
+}))
+jest.mock('../../../../Services/firebase/Database', () => ({
+  __esModule: true,
+  default: {
+    dbConnectedDrivers: jest.fn(() => ({
+      child: mockRtdbChild,
+    })),
+  },
+}))
+
+// Database/sequelize — transaction() is spied on per-test in beforeEach.
+// We do NOT mock the whole module here because Container.ts loads Models at
+// module evaluation time; a stub Sequelize instance breaks Model.init().
+const mockTransactionCommit = jest.fn().mockResolvedValue(undefined)
+const mockTransactionRollback = jest.fn().mockResolvedValue(undefined)
+const mockTransaction = { commit: mockTransactionCommit, rollback: mockTransactionRollback }
+
+// Container is required after mocks so spyOn works correctly
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const Container = require('../../../../Container/Container').default
+
+// ---------------------------------------------------------------------------
+// HTTP helpers
+// ---------------------------------------------------------------------------
+
+function post(
+  server: http.Server,
+  path: string,
+  body: any,
+  headers: Record<string, string> = {}
+): Promise<{ status: number; body: any }> {
+  return new Promise((resolve, reject) => {
+    const { port } = server.address() as AddressInfo
+    const payload = JSON.stringify(body)
+    const opts: http.RequestOptions = {
+      hostname: '127.0.0.1',
+      port,
+      path,
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(payload),
+        ...headers,
+      },
+    }
+    const req = http.request(opts, (res) => {
+      let data = ''
+      res.on('data', (chunk) => {
+        data += chunk
+      })
+      res.on('end', () => {
+        try {
+          resolve({ status: res.statusCode ?? 0, body: JSON.parse(data) })
+        } catch {
+          resolve({ status: res.statusCode ?? 0, body: data })
+        }
+      })
+    })
+    req.on('error', reject)
+    req.write(payload)
+    req.end()
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Server setup
+// ---------------------------------------------------------------------------
+
+let server: http.Server
+
+beforeAll((done) => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const controller = require('../DriverAppController').default
+  const app = express()
+  app.use(express.json())
+  app.use('/driver-app', controller)
+  server = http.createServer(app)
+  server.listen(0, '127.0.0.1', done)
+})
+
+afterAll((done) => {
+  server.close(done)
+})
+
+beforeEach(() => {
+  jest.clearAllMocks()
+
+  // Reset transaction mocks
+  mockTransactionCommit.mockResolvedValue(undefined)
+  mockTransactionRollback.mockResolvedValue(undefined)
+
+  // Spy on sequelize.transaction per-test
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const sequelizeInstance = require('../../../../Database/sequelize').default
+  jest.spyOn(sequelizeInstance, 'transaction').mockResolvedValue(mockTransaction as any)
+
+  // Spy on Container methods needed by DriverAppController
+  jest.spyOn(Container, 'getServiceHistoryRepository').mockReturnValue({
+    listByDriver: jest.fn().mockResolvedValue([]),
+  })
+  jest.spyOn(Container, 'getDriverTokenRecordRepository').mockReturnValue({
+    upsert: jest.fn().mockResolvedValue({}),
+    deleteByDriverId: jest.fn().mockResolvedValue(undefined),
+  })
+
+  // Reset RTDB mocks
+  mockRtdbChild.mockReturnValue({
+    set: mockRtdbChildSet,
+    remove: mockRtdbChildRemove,
+  })
+  mockRtdbChildSet.mockResolvedValue(undefined)
+  mockRtdbChildRemove.mockResolvedValue(undefined)
+})
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
+// ---------------------------------------------------------------------------
+// POST /driver-app/me/connect — test cases
+// ---------------------------------------------------------------------------
+
+const DRIVER_UID = 'test-driver-uid'
+const VEHICLE_ID = 'veh-uuid-123'
+
+function makeEnabledDriver(overrides: Record<string, any> = {}) {
+  return {
+    get: (_opts: any) => ({
+      id: DRIVER_UID,
+      name: 'Test Driver',
+      enabled_at: '1700000000',
+      ...overrides,
+    }),
+  }
+}
+
+function makeEnabledVehicle(overrides: Record<string, any> = {}) {
+  return {
+    get: (_opts: any) => ({ id: VEHICLE_ID, plate: 'ABC123', enabled: true, ...overrides }),
+  }
+}
+
+function makeLink(overrides: Record<string, any> = {}) {
+  return {
+    vehicle_id: VEHICLE_ID,
+    selectable: true,
+    ...overrides,
+  }
+}
+
+describe('POST /driver-app/me/connect (DriverAppController)', () => {
+  describe('400: vehicle_disabled', () => {
+    it('returns 400 with error=vehicle_disabled when vehicle.enabled is false', async () => {
+      mockDriverRecordFindByPk.mockResolvedValue(makeEnabledDriver())
+      mockVehicleRecordFindByPk.mockResolvedValue(makeEnabledVehicle({ enabled: false }))
+
+      const { status, body } = await post(server, '/driver-app/me/connect', {
+        vehicle_id: VEHICLE_ID,
+      })
+
+      expect(status).toBe(400)
+      expect(body.error).toBe('vehicle_disabled')
+      expect(mockActiveVehicleAssignmentCreate).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('400: vehicle_not_selectable', () => {
+    it('returns 400 with error=vehicle_not_selectable when no link exists for that vehicle', async () => {
+      mockDriverRecordFindByPk.mockResolvedValue(makeEnabledDriver())
+      mockVehicleRecordFindByPk.mockResolvedValue(makeEnabledVehicle())
+      // No link for this vehicle
+      mockDriverVehicleListForDriver.mockResolvedValue([])
+
+      const { status, body } = await post(server, '/driver-app/me/connect', {
+        vehicle_id: VEHICLE_ID,
+      })
+
+      expect(status).toBe(400)
+      expect(body.error).toBe('vehicle_not_selectable')
+      expect(mockActiveVehicleAssignmentCreate).not.toHaveBeenCalled()
+    })
+
+    it('returns 400 with error=vehicle_not_selectable when link exists but selectable=false', async () => {
+      mockDriverRecordFindByPk.mockResolvedValue(makeEnabledDriver())
+      mockVehicleRecordFindByPk.mockResolvedValue(makeEnabledVehicle())
+      mockDriverVehicleListForDriver.mockResolvedValue([makeLink({ selectable: false })])
+
+      const { status, body } = await post(server, '/driver-app/me/connect', {
+        vehicle_id: VEHICLE_ID,
+      })
+
+      expect(status).toBe(400)
+      expect(body.error).toBe('vehicle_not_selectable')
+      expect(mockActiveVehicleAssignmentCreate).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('403: driver_disabled', () => {
+    it('returns 403 with error=driver_disabled when driver.enabled_at is null', async () => {
+      mockDriverRecordFindByPk.mockResolvedValue(makeEnabledDriver({ enabled_at: null }))
+
+      const { status, body } = await post(server, '/driver-app/me/connect', {
+        vehicle_id: VEHICLE_ID,
+      })
+
+      expect(status).toBe(403)
+      expect(body.error).toBe('driver_disabled')
+      expect(mockVehicleRecordFindByPk).not.toHaveBeenCalled()
+      expect(mockActiveVehicleAssignmentCreate).not.toHaveBeenCalled()
+    })
+
+    it('returns 403 with error=driver_disabled when driver.enabled_at is 0', async () => {
+      mockDriverRecordFindByPk.mockResolvedValue(makeEnabledDriver({ enabled_at: 0 }))
+
+      const { status, body } = await post(server, '/driver-app/me/connect', {
+        vehicle_id: VEHICLE_ID,
+      })
+
+      expect(status).toBe(403)
+      expect(body.error).toBe('driver_disabled')
+    })
+  })
+
+  describe('409: vehicle_in_use', () => {
+    it('returns 409 with error=vehicle_in_use and held_by when vehicle PK constraint fires', async () => {
+      const holderDriverId = 'holder-driver-uid'
+      mockDriverRecordFindByPk
+        .mockResolvedValueOnce(makeEnabledDriver()) // for the requesting driver
+        .mockResolvedValueOnce({
+          // for the holder driver lookup
+          get: (_opts: any) => ({ id: holderDriverId, name: 'Holder Driver' }),
+        })
+      mockVehicleRecordFindByPk.mockResolvedValue(makeEnabledVehicle())
+      mockDriverVehicleListForDriver.mockResolvedValue([makeLink()])
+
+      // Simulate PK constraint violation on vehicle_id
+      const pkError = new UniqueConstraintError({ errors: [] })
+      ;(pkError as any).parent = { constraint: 'active_vehicle_assignments_pkey' }
+      mockActiveVehicleAssignmentCreate.mockRejectedValue(pkError)
+
+      // The repository is asked who holds the vehicle
+      mockActiveVehicleAssignmentFindByVehicle.mockResolvedValue({
+        vehicle_id: VEHICLE_ID,
+        driver_id: holderDriverId,
+        session_id: null,
+        acquired_at: new Date(),
+      })
+
+      const { status, body } = await post(server, '/driver-app/me/connect', {
+        vehicle_id: VEHICLE_ID,
+      })
+
+      expect(status).toBe(409)
+      expect(body.error).toBe('vehicle_in_use')
+      expect(body.held_by).toEqual({ id: holderDriverId, name: 'Holder Driver' })
+      expect(mockTransactionRollback).toHaveBeenCalledTimes(1)
+      expect(mockRtdbChildSet).not.toHaveBeenCalled()
+    })
+
+    it('returns 409 with error=vehicle_in_use and held_by=null when no assignment record is found', async () => {
+      mockDriverRecordFindByPk.mockResolvedValue(makeEnabledDriver())
+      mockVehicleRecordFindByPk.mockResolvedValue(makeEnabledVehicle())
+      mockDriverVehicleListForDriver.mockResolvedValue([makeLink()])
+
+      const pkError = new UniqueConstraintError({ errors: [] })
+      ;(pkError as any).parent = { constraint: 'active_vehicle_assignments_pkey' }
+      mockActiveVehicleAssignmentCreate.mockRejectedValue(pkError)
+      mockActiveVehicleAssignmentFindByVehicle.mockResolvedValue(null)
+
+      const { status, body } = await post(server, '/driver-app/me/connect', {
+        vehicle_id: VEHICLE_ID,
+      })
+
+      expect(status).toBe(409)
+      expect(body.error).toBe('vehicle_in_use')
+      expect(body.held_by).toBeNull()
+    })
+  })
+
+  describe('409: driver_already_connected', () => {
+    it('returns 409 with error=driver_already_connected when driver_id unique constraint fires', async () => {
+      mockDriverRecordFindByPk.mockResolvedValue(makeEnabledDriver())
+      mockVehicleRecordFindByPk.mockResolvedValue(makeEnabledVehicle())
+      mockDriverVehicleListForDriver.mockResolvedValue([makeLink()])
+
+      // Simulate unique constraint on driver_id column
+      const driverError = new UniqueConstraintError({ errors: [] })
+      ;(driverError as any).parent = { constraint: 'active_vehicle_assignments_driver_id_key' }
+      mockActiveVehicleAssignmentCreate.mockRejectedValue(driverError)
+
+      const { status, body } = await post(server, '/driver-app/me/connect', {
+        vehicle_id: VEHICLE_ID,
+      })
+
+      expect(status).toBe(409)
+      expect(body.error).toBe('driver_already_connected')
+      expect(mockTransactionRollback).toHaveBeenCalledTimes(1)
+      expect(mockRtdbChildSet).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('200: success', () => {
+    it('returns 200, commits txn, and writes RTDB presence on happy path', async () => {
+      mockDriverRecordFindByPk.mockResolvedValue(makeEnabledDriver())
+      mockVehicleRecordFindByPk.mockResolvedValue(makeEnabledVehicle())
+      mockDriverVehicleListForDriver.mockResolvedValue([makeLink()])
+      mockActiveVehicleAssignmentCreate.mockResolvedValue({})
+      mockRtdbChildSet.mockResolvedValue(undefined)
+
+      const { status, body } = await post(server, '/driver-app/me/connect', {
+        vehicle_id: VEHICLE_ID,
+        session_id: 'sess-abc',
+      })
+
+      expect(status).toBe(200)
+      expect(body.success).toBe(true)
+      expect(mockActiveVehicleAssignmentCreate).toHaveBeenCalledTimes(1)
+      expect(mockActiveVehicleAssignmentCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          vehicle_id: VEHICLE_ID,
+          driver_id: DRIVER_UID,
+          session_id: 'sess-abc',
+        }),
+        { transaction: mockTransaction }
+      )
+      expect(mockRtdbChild).toHaveBeenCalledWith(DRIVER_UID)
+      expect(mockRtdbChildSet).toHaveBeenCalledTimes(1)
+      expect(mockRtdbChildSet).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: DRIVER_UID,
+          vehicle_id: VEHICLE_ID,
+          session_id: 'sess-abc',
+        })
+      )
+      expect(mockTransactionCommit).toHaveBeenCalledTimes(1)
+      expect(mockTransactionRollback).not.toHaveBeenCalled()
+    })
+
+    it('rolls back and returns 503 when RTDB write fails', async () => {
+      mockDriverRecordFindByPk.mockResolvedValue(makeEnabledDriver())
+      mockVehicleRecordFindByPk.mockResolvedValue(makeEnabledVehicle())
+      mockDriverVehicleListForDriver.mockResolvedValue([makeLink()])
+      mockActiveVehicleAssignmentCreate.mockResolvedValue({})
+      mockRtdbChildSet.mockRejectedValue(new Error('RTDB unavailable'))
+
+      const { status, body } = await post(server, '/driver-app/me/connect', {
+        vehicle_id: VEHICLE_ID,
+      })
+
+      expect(status).toBe(503)
+      expect(body.error).toBe('presence_unavailable')
+      expect(mockTransactionRollback).toHaveBeenCalledTimes(1)
+      expect(mockTransactionCommit).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/Api/Controllers/Drivers/__tests__/DriverAppController.spec.ts
+++ b/src/Api/Controllers/Drivers/__tests__/DriverAppController.spec.ts
@@ -521,3 +521,56 @@ describe('POST /driver-app/me/connect (DriverAppController)', () => {
     })
   })
 })
+
+describe('GET /driver-app/me/vehicles (DriverAppController)', () => {
+  it('returns both selectable and is_selectable using the enabled/selectable roster filter', async () => {
+    mockDriverVehicleListForDriver.mockResolvedValue([
+      {
+        vehicle_id: 'veh-eligible',
+        selectable: true,
+        vehicle: {
+          id: 'veh-eligible',
+          plate: 'ABC123',
+          brand: 'Toyota',
+          model: 'Yaris',
+          photoUrl: 'https://img/1.png',
+          color: { name: 'White' },
+          enabled: true,
+        },
+      },
+    ])
+    mockDriverRecordFindByPk.mockResolvedValue({
+      get: (_opts: any) => ({ selected_vehicle_id: 'veh-eligible' }),
+    })
+    mockActiveVehicleAssignmentFindByDriver.mockResolvedValue({
+      vehicle_id: 'veh-eligible',
+      driver_id: DRIVER_UID,
+      session_id: null,
+      acquired_at: new Date(),
+    })
+
+    const { status, body } = await get(server, '/driver-app/me/vehicles')
+
+    expect(status).toBe(200)
+    expect(body.success).toBe(true)
+    expect(mockDriverVehicleListForDriver).toHaveBeenCalledWith(DRIVER_UID, {
+      includeAll: false,
+    })
+    expect(body.data.vehicles).toEqual([
+      {
+        id: 'veh-eligible',
+        plate: 'ABC123',
+        brand: 'Toyota',
+        model: 'Yaris',
+        photoUrl: 'https://img/1.png',
+        color: { name: 'White' },
+        enabled: true,
+        vehicle_id: 'veh-eligible',
+        selectable: true,
+        is_selectable: true,
+        is_selected: true,
+        is_active: true,
+      },
+    ])
+  })
+})

--- a/src/Api/Controllers/Drivers/__tests__/DriverAppController.spec.ts
+++ b/src/Api/Controllers/Drivers/__tests__/DriverAppController.spec.ts
@@ -496,6 +496,7 @@ describe('POST /driver-app/me/connect (DriverAppController)', () => {
         expect.objectContaining({
           id: DRIVER_UID,
           vehicle_id: VEHICLE_ID,
+          vehicle_plate: 'ABC123',
           session_id: 'sess-abc',
         })
       )

--- a/src/Api/Controllers/Drivers/__tests__/DriverAppController.spec.ts
+++ b/src/Api/Controllers/Drivers/__tests__/DriverAppController.spec.ts
@@ -29,11 +29,12 @@ jest.mock('../../../../Middlewares/Authorization', () => ({
 
 // DriverRecord — Sequelize Model used directly in DriverAppController
 const mockDriverRecordFindByPk = jest.fn()
+const mockDriverRecordUpdate = jest.fn()
 jest.mock('../../../../Models/DriverRecord', () => ({
   __esModule: true,
   default: {
     findByPk: mockDriverRecordFindByPk,
-    update: jest.fn(),
+    update: mockDriverRecordUpdate,
   },
   setupDriverAssociations: jest.fn(),
 }))
@@ -59,11 +60,12 @@ jest.mock('../../../../Models/ActiveVehicleAssignmentRecord', () => ({
 // ActiveVehicleAssignmentRepository — singleton default export
 const mockActiveVehicleAssignmentFindByVehicle = jest.fn()
 const mockActiveVehicleAssignmentReleaseByDriver = jest.fn()
+const mockActiveVehicleAssignmentFindByDriver = jest.fn()
 jest.mock('../../../../Repositories/ActiveVehicleAssignmentRepository', () => ({
   __esModule: true,
   default: {
     findByVehicle: mockActiveVehicleAssignmentFindByVehicle,
-    findByDriver: jest.fn(),
+    findByDriver: mockActiveVehicleAssignmentFindByDriver,
     releaseByDriver: mockActiveVehicleAssignmentReleaseByDriver,
     releaseByVehicle: jest.fn(),
     acquire: jest.fn(),
@@ -154,6 +156,77 @@ function post(
   })
 }
 
+function get(
+  server: http.Server,
+  path: string,
+  headers: Record<string, string> = {}
+): Promise<{ status: number; body: any }> {
+  return new Promise((resolve, reject) => {
+    const { port } = server.address() as AddressInfo
+    const opts: http.RequestOptions = {
+      hostname: '127.0.0.1',
+      port,
+      path,
+      method: 'GET',
+      headers,
+    }
+    const req = http.request(opts, (res) => {
+      let data = ''
+      res.on('data', (chunk) => {
+        data += chunk
+      })
+      res.on('end', () => {
+        try {
+          resolve({ status: res.statusCode ?? 0, body: JSON.parse(data) })
+        } catch {
+          resolve({ status: res.statusCode ?? 0, body: data })
+        }
+      })
+    })
+    req.on('error', reject)
+    req.end()
+  })
+}
+
+function put(
+  server: http.Server,
+  path: string,
+  body: any,
+  headers: Record<string, string> = {}
+): Promise<{ status: number; body: any }> {
+  return new Promise((resolve, reject) => {
+    const { port } = server.address() as AddressInfo
+    const payload = JSON.stringify(body)
+    const opts: http.RequestOptions = {
+      hostname: '127.0.0.1',
+      port,
+      path,
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(payload),
+        ...headers,
+      },
+    }
+    const req = http.request(opts, (res) => {
+      let data = ''
+      res.on('data', (chunk) => {
+        data += chunk
+      })
+      res.on('end', () => {
+        try {
+          resolve({ status: res.statusCode ?? 0, body: JSON.parse(data) })
+        } catch {
+          resolve({ status: res.statusCode ?? 0, body: data })
+        }
+      })
+    })
+    req.on('error', reject)
+    req.write(payload)
+    req.end()
+  })
+}
+
 // ---------------------------------------------------------------------------
 // Server setup
 // ---------------------------------------------------------------------------
@@ -202,6 +275,8 @@ beforeEach(() => {
   })
   mockRtdbChildSet.mockResolvedValue(undefined)
   mockRtdbChildRemove.mockResolvedValue(undefined)
+  mockDriverRecordUpdate.mockReset()
+  mockActiveVehicleAssignmentFindByDriver.mockReset()
 })
 
 afterEach(() => {

--- a/src/Api/Controllers/Drivers/__tests__/DriversController.spec.ts
+++ b/src/Api/Controllers/Drivers/__tests__/DriversController.spec.ts
@@ -1396,3 +1396,108 @@ describe('GET /drivers/:id (DriversController)', () => {
     expect(mockVehicleRepoFindById).not.toHaveBeenCalled()
   })
 })
+
+describe('GET /public/drivers/:id (PublicDriversController)', () => {
+  const baseDriver = {
+    id: 'drv-public-1',
+    name: 'Public Driver',
+    email: 'driver@test.com',
+    phone: '555-0000',
+    docType: 'cc',
+    document: '111111',
+    paymentMode: 'monthly',
+    balance: 0,
+    enabled_at: 0,
+    created_at: 0,
+    last_connection: 0,
+    vehicle: { plate: 'LEGACY123' },
+    selected_vehicle_id: 'veh-2',
+  }
+
+  it('returns selected_vehicle_id, selected_vehicle, and a flat Android-compatible roster', async () => {
+    mockFindById.mockResolvedValue(baseDriver)
+    mockDriverVehicleListForDriver.mockResolvedValue([
+      {
+        vehicle_id: 'veh-2',
+        selectable: true,
+        vehicle: {
+          id: 'veh-2',
+          plate: 'ABC123',
+          brand: 'Toyota',
+          model: 'Yaris',
+          photoUrl: 'https://img/1.png',
+          color: { name: 'White' },
+          enabled: true,
+        },
+      },
+      {
+        vehicle_id: 'veh-3',
+        selectable: true,
+        vehicle: {
+          id: 'veh-3',
+          plate: 'XYZ789',
+          brand: 'Mazda',
+          model: '2',
+          photoUrl: null,
+          color: { name: 'Red' },
+          enabled: false,
+        },
+      },
+    ])
+    mockActiveVehicleAssignmentFindByDriver.mockResolvedValue({
+      vehicle_id: 'veh-3',
+      driver_id: 'drv-public-1',
+      session_id: null,
+      acquired_at: new Date(),
+    })
+
+    const { status, body } = await get(server, '/public/drivers/drv-public-1')
+
+    expect(status).toBe(200)
+    expect(body.success).toBe(true)
+    expect(mockDriverVehicleListForDriver).toHaveBeenCalledWith('drv-public-1', { includeAll: true })
+
+    const driver = body.data.driver
+    expect(driver.selected_vehicle_id).toBe('veh-2')
+    expect(driver.selected_vehicle).toEqual({
+      id: 'veh-2',
+      plate: 'ABC123',
+      brand: 'Toyota',
+      model: 'Yaris',
+      photoUrl: 'https://img/1.png',
+      color: { name: 'White' },
+      enabled: true,
+      is_selected: true,
+      is_selectable: true,
+      is_active: false,
+    })
+    expect(driver.roster).toEqual([
+      {
+        id: 'veh-2',
+        plate: 'ABC123',
+        brand: 'Toyota',
+        model: 'Yaris',
+        photoUrl: 'https://img/1.png',
+        color: { name: 'White' },
+        enabled: true,
+        is_selected: true,
+        is_selectable: true,
+        is_active: false,
+      },
+      {
+        id: 'veh-3',
+        plate: 'XYZ789',
+        brand: 'Mazda',
+        model: '2',
+        photoUrl: null,
+        color: { name: 'Red' },
+        enabled: false,
+        is_selected: false,
+        is_selectable: false,
+        is_active: true,
+      },
+    ])
+    expect(driver.roster.filter((vehicle: any) => vehicle.is_selected)).toHaveLength(1)
+    expect(driver.roster[0].vehicle).toBeUndefined()
+  })
+})

--- a/src/Api/Controllers/Drivers/__tests__/DriversController.spec.ts
+++ b/src/Api/Controllers/Drivers/__tests__/DriversController.spec.ts
@@ -291,14 +291,15 @@ describe('GET /drivers (DriversController)', () => {
   // --- fallback to index() when no listed params ---
 
   describe('200: no listed params falls back to index()', () => {
-    it('calls index() and returns { drivers, total } when no filter/sort/page params are present', async () => {
+    it('calls index() and returns { success, data: { drivers, total } } when no filter/sort/page params are present', async () => {
       mockIndex.mockResolvedValue([{ id: 'drv-1' }])
 
       const { status, body } = await get(server, '/drivers', VALID_AUTH_HEADERS)
 
       expect(status).toBe(200)
-      expect(body.drivers).toHaveLength(1)
-      expect(body.total).toBe(1)
+      expect(body.success).toBe(true)
+      expect(body.data.drivers).toHaveLength(1)
+      expect(body.data.total).toBe(1)
       expect(mockList).not.toHaveBeenCalled()
     })
   })

--- a/src/Api/Controllers/Drivers/__tests__/DriversController.spec.ts
+++ b/src/Api/Controllers/Drivers/__tests__/DriversController.spec.ts
@@ -323,10 +323,11 @@ const mockStore = jest.fn()
 
 beforeAll((done) => {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const controller = require('../DriversController').default
+  const controllerModule = require('../DriversController')
   const app = express()
   app.use(express.json())
-  app.use('/drivers', controller)
+  app.use('/drivers', controllerModule.default)
+  app.use('/public/drivers', controllerModule.PublicDriversController)
   server = http.createServer(app)
   server.listen(0, '127.0.0.1', done)
 })
@@ -1020,7 +1021,14 @@ describe('POST /drivers/:id/vehicles (find-or-create reuse)', () => {
     const { status, body } = await post(
       server,
       `/drivers/${driverId}/vehicles`,
-      { vehicle: { plate: 'ABC123', brand: 'OtherBrand' } },
+      {
+        vehicle: {
+          plate: 'ABC123',
+          brand: 'OtherBrand',
+          model: 'Picanto',
+          color: { name: 'Blue' },
+        },
+      },
       VALID_AUTH_HEADERS
     )
 
@@ -1032,7 +1040,12 @@ describe('POST /drivers/:id/vehicles (find-or-create reuse)', () => {
     expect(mockFindOrCreateByPlate).toHaveBeenCalledTimes(1)
     expect(mockFindOrCreateByPlate).toHaveBeenCalledWith(
       'ABC123',
-      { plate: 'ABC123', brand: 'OtherBrand' },
+      {
+        plate: 'ABC123',
+        brand: 'OtherBrand',
+        model: 'Picanto',
+        color: { name: 'Blue' },
+      },
       mockTransaction
     )
     // link was created for the existing vehicle
@@ -1061,7 +1074,14 @@ describe('POST /drivers/:id/vehicles (find-or-create reuse)', () => {
     const { status, body } = await post(
       server,
       `/drivers/${driverId}/vehicles`,
-      { vehicle: { plate: 'XYZ789', brand: 'Toyota' } },
+      {
+        vehicle: {
+          plate: 'XYZ789',
+          brand: 'Toyota',
+          model: 'Corolla',
+          color: { name: 'White' },
+        },
+      },
       VALID_AUTH_HEADERS
     )
 

--- a/src/Api/Controllers/Drivers/__tests__/DriversController.spec.ts
+++ b/src/Api/Controllers/Drivers/__tests__/DriversController.spec.ts
@@ -320,6 +320,8 @@ const mockBulkSetEnabled = jest.fn()
 const mockFindByDriverId = jest.fn()
 const mockFindById = jest.fn()
 const mockStore = jest.fn()
+const mockRechargeCreate = jest.fn()
+const mockRechargeListForDriver = jest.fn()
 
 beforeAll((done) => {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -383,6 +385,12 @@ beforeEach(() => {
   jest.spyOn(Container, 'getDriverTokenRecordRepository').mockReturnValue({
     findByDriverId: mockFindByDriverId,
   })
+  jest.spyOn(Container, 'getRechargeRepository').mockReturnValue({
+    create: mockRechargeCreate,
+    listForDriver: mockRechargeListForDriver,
+  } as any)
+  mockRechargeCreate.mockReset()
+  mockRechargeListForDriver.mockReset()
 })
 
 afterEach(() => {
@@ -1394,6 +1402,169 @@ describe('GET /drivers/:id (DriversController)', () => {
     expect(body.data.driver.selected_vehicle).toBeNull()
     expect(body.data.driver.active_vehicle_id).toBeNull()
     expect(mockVehicleRepoFindById).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// POST /drivers/:id/recharges
+// ---------------------------------------------------------------------------
+
+describe('POST /drivers/:id/recharges (DriversController)', () => {
+  const validBody = {
+    amount: 5000,
+    created_by: { uid: 'admin-uid', name: 'Admin User' },
+    note: 'recarga efectivo',
+  }
+  const rechargeResult = {
+    recharge: {
+      id: 'rch-1', driverId: 'drv-1', amount: 5000,
+      balanceBefore: 1000, balanceAfter: 6000,
+      createdByUid: 'admin-uid', createdByName: 'Admin User',
+      note: 'recarga efectivo', created_at: 1000000,
+    },
+    driver: { id: 'drv-1', balance: 6000 },
+  }
+
+  describe('201: successful recharge', () => {
+    it('creates recharge and returns recharge + driver', async () => {
+      mockRechargeCreate.mockResolvedValue(rechargeResult)
+
+      const { status, body } = await post(server, '/drivers/drv-1/recharges', validBody, VALID_AUTH_HEADERS)
+
+      expect(status).toBe(201)
+      expect(body.success).toBe(true)
+      expect(body.data.recharge).toEqual(rechargeResult.recharge)
+      expect(body.data.driver).toEqual(rechargeResult.driver)
+      expect(mockRechargeCreate).toHaveBeenCalledTimes(1)
+      expect(mockRechargeCreate).toHaveBeenCalledWith({
+        driverId: 'drv-1',
+        amount: 5000,
+        createdBy: { uid: 'admin-uid', name: 'Admin User' },
+        note: 'recarga efectivo',
+      })
+    })
+
+    it('calls store.refreshDrivers() after successful recharge', async () => {
+      mockRechargeCreate.mockResolvedValue(rechargeResult)
+
+      await post(server, '/drivers/drv-1/recharges', validBody, VALID_AUTH_HEADERS)
+
+      expect(mockRefreshDrivers).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('400: validation errors', () => {
+    it('returns 400 when amount is missing', async () => {
+      const { status, body } = await post(
+        server, '/drivers/drv-1/recharges',
+        { created_by: { uid: 'u', name: 'n' } },
+        VALID_AUTH_HEADERS
+      )
+      expect(status).toBe(400)
+      expect(body.success).toBe(false)
+      expect(mockRechargeCreate).not.toHaveBeenCalled()
+    })
+
+    it('returns 400 when amount is zero', async () => {
+      const { status, body } = await post(
+        server, '/drivers/drv-1/recharges',
+        { amount: 0, created_by: { uid: 'u', name: 'n' } },
+        VALID_AUTH_HEADERS
+      )
+      expect(status).toBe(400)
+      expect(body.success).toBe(false)
+      expect(mockRechargeCreate).not.toHaveBeenCalled()
+    })
+
+    it('returns 400 when amount is a string', async () => {
+      const { status, body } = await post(
+        server, '/drivers/drv-1/recharges',
+        { amount: '5000', created_by: { uid: 'u', name: 'n' } },
+        VALID_AUTH_HEADERS
+      )
+      expect(status).toBe(400)
+      expect(body.success).toBe(false)
+    })
+
+    it('returns 400 when created_by is missing', async () => {
+      const { status, body } = await post(
+        server, '/drivers/drv-1/recharges',
+        { amount: 5000 },
+        VALID_AUTH_HEADERS
+      )
+      expect(status).toBe(400)
+      expect(body.success).toBe(false)
+      expect(mockRechargeCreate).not.toHaveBeenCalled()
+    })
+
+    it('returns 400 when created_by.uid is missing', async () => {
+      const { status, body } = await post(
+        server, '/drivers/drv-1/recharges',
+        { amount: 5000, created_by: { name: 'Admin' } },
+        VALID_AUTH_HEADERS
+      )
+      expect(status).toBe(400)
+      expect(body.success).toBe(false)
+    })
+  })
+
+  describe('404: driver not found', () => {
+    it('returns 404 when repository throws Driver not found', async () => {
+      mockRechargeCreate.mockRejectedValue(new Error('Driver not found'))
+
+      const { status, body } = await post(
+        server, '/drivers/nonexistent/recharges',
+        validBody,
+        VALID_AUTH_HEADERS
+      )
+
+      expect(status).toBe(404)
+      expect(body.success).toBe(false)
+      expect(mockRefreshDrivers).not.toHaveBeenCalled()
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// GET /drivers/:id/recharges
+// ---------------------------------------------------------------------------
+
+describe('GET /drivers/:id/recharges (DriversController)', () => {
+  const sampleRecharges = [
+    { id: 'rch-2', driverId: 'drv-1', amount: -2000, balanceBefore: 6000, balanceAfter: 4000, createdByUid: 'u', createdByName: 'Admin', note: null, created_at: 1000100 },
+    { id: 'rch-1', driverId: 'drv-1', amount: 5000, balanceBefore: 1000, balanceAfter: 6000, createdByUid: 'u', createdByName: 'Admin', note: 'recarga', created_at: 1000000 },
+  ]
+
+  describe('200: returns paginated history', () => {
+    it('returns recharges and total', async () => {
+      mockRechargeListForDriver.mockResolvedValue({ rows: sampleRecharges, total: 2 })
+
+      const { status, body } = await get(server, '/drivers/drv-1/recharges', VALID_AUTH_HEADERS)
+
+      expect(status).toBe(200)
+      expect(body.success).toBe(true)
+      expect(body.data.recharges).toHaveLength(2)
+      expect(body.data.total).toBe(2)
+      expect(mockRechargeListForDriver).toHaveBeenCalledWith('drv-1', { page: 1, perPage: 20 })
+    })
+
+    it('returns empty list when driver has no recharges', async () => {
+      mockRechargeListForDriver.mockResolvedValue({ rows: [], total: 0 })
+
+      const { status, body } = await get(server, '/drivers/drv-1/recharges', VALID_AUTH_HEADERS)
+
+      expect(status).toBe(200)
+      expect(body.data.recharges).toEqual([])
+      expect(body.data.total).toBe(0)
+    })
+
+    it('forwards page and perPage query params', async () => {
+      mockRechargeListForDriver.mockResolvedValue({ rows: [], total: 0 })
+
+      await get(server, '/drivers/drv-1/recharges?page=2&perPage=10', VALID_AUTH_HEADERS)
+
+      expect(mockRechargeListForDriver).toHaveBeenCalledWith('drv-1', { page: 2, perPage: 10 })
+    })
   })
 })
 

--- a/src/Api/Controllers/Drivers/__tests__/DriversController.spec.ts
+++ b/src/Api/Controllers/Drivers/__tests__/DriversController.spec.ts
@@ -52,6 +52,86 @@ jest.mock('../../../../Services/firebase/FCM', () => ({
   },
 }))
 
+// DriverVehicleRepository — class instantiated at module-level in DriversController.
+const mockDriverVehicleListForDriver = jest.fn()
+const mockDriverVehicleLink = jest.fn()
+const mockDriverVehicleSetSelectable = jest.fn()
+const mockDriverVehicleFindEligibleForDriver = jest.fn()
+const mockDriverVehicleFindMostRecentEligible = jest.fn()
+jest.mock('../../../../Repositories/DriverVehicleRepository', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({
+    listForDriver: mockDriverVehicleListForDriver,
+    link: mockDriverVehicleLink,
+    setSelectable: mockDriverVehicleSetSelectable,
+    findEligibleForDriver: mockDriverVehicleFindEligibleForDriver,
+    findMostRecentEligible: mockDriverVehicleFindMostRecentEligible,
+  })),
+}))
+
+// VehicleRepository — class instantiated at module-level in DriversController.
+const mockFindOrCreateByPlate = jest.fn()
+const mockVehicleRepoFindById = jest.fn()
+jest.mock('../../../../Repositories/VehicleRepository', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({
+    findOrCreateByPlate: mockFindOrCreateByPlate,
+    search: jest.fn(),
+    findByNormalizedPlate: jest.fn(),
+    findWithLinkedDrivers: jest.fn(),
+    findById: mockVehicleRepoFindById,
+    create: jest.fn(),
+    update: jest.fn(),
+    setEnabled: jest.fn(),
+  })),
+}))
+
+// ActiveVehicleAssignmentRepository — singleton default export.
+const mockActiveVehicleAssignmentFindByDriver = jest.fn()
+jest.mock('../../../../Repositories/ActiveVehicleAssignmentRepository', () => ({
+  __esModule: true,
+  default: {
+    findByDriver: mockActiveVehicleAssignmentFindByDriver,
+    findByVehicle: jest.fn(),
+    acquire: jest.fn(),
+    releaseByDriver: jest.fn(),
+    releaseByVehicle: jest.fn(),
+  },
+}))
+
+// DriverRecord — Sequelize Model used directly in DriversController.
+const mockDriverRecordFindByPk = jest.fn()
+const mockDriverRecordUpdate = jest.fn()
+jest.mock('../../../../Models/DriverRecord', () => ({
+  __esModule: true,
+  default: {
+    findByPk: mockDriverRecordFindByPk,
+    update: mockDriverRecordUpdate,
+  },
+  setupDriverAssociations: jest.fn(),
+}))
+
+// autoPromoteSelectedVehicle — used on selectable=false toggle.
+const mockAutoPromoteSelectedVehicle = jest.fn()
+jest.mock('../../../../Services/drivers/AutoPromoteVehicle', () => ({
+  __esModule: true,
+  autoPromoteSelectedVehicle: (...args: any[]) => mockAutoPromoteSelectedVehicle(...args),
+}))
+
+// ForceDisconnect service — mock so no Firebase calls occur in tests.
+const mockForceDisconnect = jest.fn()
+jest.mock('../../../../Services/drivers/ForceDisconnect', () => ({
+  __esModule: true,
+  forceDisconnect: (...args: any[]) => mockForceDisconnect(...args),
+}))
+
+// Database/sequelize — transaction() is spied on per-test in beforeEach.
+// We do NOT mock the whole module here because Container.ts loads Models at
+// module evaluation time; a stub Sequelize instance breaks Model.init().
+const mockTransactionCommit = jest.fn().mockResolvedValue(undefined)
+const mockTransactionRollback = jest.fn().mockResolvedValue(undefined)
+const mockTransaction = { commit: mockTransactionCommit, rollback: mockTransactionRollback }
+
 // ---------------------------------------------------------------------------
 // Typed accessors for mocked modules
 // ---------------------------------------------------------------------------
@@ -143,6 +223,84 @@ function post(
   })
 }
 
+function patch(
+  server: http.Server,
+  path: string,
+  body: any,
+  headers: Record<string, string> = {}
+): Promise<{ status: number; body: any }> {
+  return new Promise((resolve, reject) => {
+    const { port } = server.address() as AddressInfo
+    const payload = JSON.stringify(body)
+    const opts: http.RequestOptions = {
+      hostname: '127.0.0.1',
+      port,
+      path,
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(payload),
+        ...headers,
+      },
+    }
+    const req = http.request(opts, (res) => {
+      let data = ''
+      res.on('data', (chunk) => {
+        data += chunk
+      })
+      res.on('end', () => {
+        try {
+          resolve({ status: res.statusCode ?? 0, body: JSON.parse(data) })
+        } catch {
+          resolve({ status: res.statusCode ?? 0, body: data })
+        }
+      })
+    })
+    req.on('error', reject)
+    req.write(payload)
+    req.end()
+  })
+}
+
+function put(
+  server: http.Server,
+  path: string,
+  body: any,
+  headers: Record<string, string> = {}
+): Promise<{ status: number; body: any }> {
+  return new Promise((resolve, reject) => {
+    const { port } = server.address() as AddressInfo
+    const payload = JSON.stringify(body)
+    const opts: http.RequestOptions = {
+      hostname: '127.0.0.1',
+      port,
+      path,
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(payload),
+        ...headers,
+      },
+    }
+    const req = http.request(opts, (res) => {
+      let data = ''
+      res.on('data', (chunk) => {
+        data += chunk
+      })
+      res.on('end', () => {
+        try {
+          resolve({ status: res.statusCode ?? 0, body: JSON.parse(data) })
+        } catch {
+          resolve({ status: res.statusCode ?? 0, body: data })
+        }
+      })
+    })
+    req.on('error', reject)
+    req.write(payload)
+    req.end()
+  })
+}
+
 const VALID_AUTH_HEADERS = {
   authorization: 'Bearer test-api-key',
   'x-client-platform': 'admin',
@@ -160,6 +318,8 @@ const mockList = jest.fn()
 const mockIndex = jest.fn()
 const mockBulkSetEnabled = jest.fn()
 const mockFindByDriverId = jest.fn()
+const mockFindById = jest.fn()
+const mockStore = jest.fn()
 
 beforeAll((done) => {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -181,6 +341,7 @@ beforeEach(() => {
   mockIndex.mockReset()
   mockBulkSetEnabled.mockReset()
   mockFindByDriverId.mockReset()
+  mockFindById.mockReset()
   mockRefreshDrivers.mockReset()
   mockRefreshDrivers.mockResolvedValue(undefined)
   MockedDriverRepository.default.removeDriver.mockReset()
@@ -188,10 +349,35 @@ beforeEach(() => {
   MockedFCM.default.sendNotificationTo.mockReset()
   MockedFCM.default.sendNotificationTo.mockResolvedValue(undefined)
   MockedAuth.requireAuth.mockImplementation((_req: any, _res: any, next: any) => next())
+  // Reset vehicle-related mocks
+  mockDriverVehicleListForDriver.mockReset()
+  mockDriverVehicleLink.mockReset()
+  mockDriverVehicleSetSelectable.mockReset()
+  mockDriverVehicleFindEligibleForDriver.mockReset()
+  mockDriverVehicleFindMostRecentEligible.mockReset()
+  mockFindOrCreateByPlate.mockReset()
+  mockActiveVehicleAssignmentFindByDriver.mockReset()
+  mockDriverRecordFindByPk.mockReset()
+  mockDriverRecordUpdate.mockReset()
+  mockAutoPromoteSelectedVehicle.mockReset()
+  mockForceDisconnect.mockReset()
+  mockForceDisconnect.mockResolvedValue(undefined)
+  mockTransactionCommit.mockReset()
+  mockTransactionRollback.mockReset()
+  mockTransactionCommit.mockResolvedValue(undefined)
+  mockTransactionRollback.mockResolvedValue(undefined)
+  // Spy on sequelize.transaction so POST /:id/vehicles can be tested without a real DB.
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const sequelizeInstance = require('../../../../Database/sequelize').default
+  jest.spyOn(sequelizeInstance, 'transaction').mockResolvedValue(mockTransaction as any)
+  mockStore.mockReset()
+  mockVehicleRepoFindById.mockReset()
   jest.spyOn(Container, 'getDriverRecordRepository').mockReturnValue({
     list: mockList,
     index: mockIndex,
     bulkSetEnabled: mockBulkSetEnabled,
+    findById: mockFindById,
+    store: mockStore,
   })
   jest.spyOn(Container, 'getDriverTokenRecordRepository').mockReturnValue({
     findByDriverId: mockFindByDriverId,
@@ -635,5 +821,558 @@ describe('POST /drivers/bulk/send-message (DriversController)', () => {
       expect(body.data.failed[0].reason).toMatch(/FCM unreachable/)
       expect(body.data.processed).toContain('drv-2')
     })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// PATCH /drivers/:id/vehicles/:vehicleId — auto-promote on toggle to selectable=false
+// ---------------------------------------------------------------------------
+
+describe('PATCH /drivers/:id/vehicles/:vehicleId (selectable toggle — auto-promote)', () => {
+  it('calls autoPromoteSelectedVehicle when selectable=false and that vehicle is the driver selected vehicle', async () => {
+    const driverId = 'drv-1'
+    const vehicleId = 'veh-selected'
+
+    mockFindById.mockResolvedValue({ id: driverId, name: 'Test Driver' })
+    mockDriverVehicleSetSelectable.mockResolvedValue(undefined)
+    // DriverRecord.findByPk returns a record whose selected_vehicle_id matches vehicleId
+    mockDriverRecordFindByPk.mockResolvedValue({
+      get: (_opts: any) => ({ selected_vehicle_id: vehicleId }),
+    })
+    mockAutoPromoteSelectedVehicle.mockResolvedValue(undefined)
+
+    const { status, body } = await patch(
+      server,
+      `/drivers/${driverId}/vehicles/${vehicleId}`,
+      { selectable: false },
+      VALID_AUTH_HEADERS
+    )
+
+    expect(status).toBe(200)
+    expect(body.success).toBe(true)
+    expect(mockDriverVehicleSetSelectable).toHaveBeenCalledWith(driverId, vehicleId, false)
+    expect(mockAutoPromoteSelectedVehicle).toHaveBeenCalledTimes(1)
+    expect(mockAutoPromoteSelectedVehicle).toHaveBeenCalledWith(driverId)
+  })
+
+  it('does NOT call autoPromoteSelectedVehicle when selectable=false but that vehicle is NOT the driver selected vehicle', async () => {
+    const driverId = 'drv-1'
+    const vehicleId = 'veh-other'
+
+    mockFindById.mockResolvedValue({ id: driverId, name: 'Test Driver' })
+    mockDriverVehicleSetSelectable.mockResolvedValue(undefined)
+    // DriverRecord.findByPk returns a record whose selected_vehicle_id is a DIFFERENT vehicle
+    mockDriverRecordFindByPk.mockResolvedValue({
+      get: (_opts: any) => ({ selected_vehicle_id: 'veh-selected' }),
+    })
+
+    const { status, body } = await patch(
+      server,
+      `/drivers/${driverId}/vehicles/${vehicleId}`,
+      { selectable: false },
+      VALID_AUTH_HEADERS
+    )
+
+    expect(status).toBe(200)
+    expect(body.success).toBe(true)
+    expect(mockAutoPromoteSelectedVehicle).not.toHaveBeenCalled()
+  })
+
+  it('does NOT call autoPromoteSelectedVehicle when selectable=true', async () => {
+    const driverId = 'drv-1'
+    const vehicleId = 'veh-selected'
+
+    mockFindById.mockResolvedValue({ id: driverId, name: 'Test Driver' })
+    mockDriverVehicleSetSelectable.mockResolvedValue(undefined)
+
+    const { status, body } = await patch(
+      server,
+      `/drivers/${driverId}/vehicles/${vehicleId}`,
+      { selectable: true },
+      VALID_AUTH_HEADERS
+    )
+
+    expect(status).toBe(200)
+    expect(body.success).toBe(true)
+    expect(mockDriverRecordFindByPk).not.toHaveBeenCalled()
+    expect(mockAutoPromoteSelectedVehicle).not.toHaveBeenCalled()
+  })
+
+  // ---------------------------------------------------------------------------
+  // Confirmation gate (task 7.3) — selectable=false with active assignment
+  // ---------------------------------------------------------------------------
+
+  it('returns 409 vehicle_active with held_by when setting selectable=false and driver is currently using that vehicle', async () => {
+    const driverId = 'drv-1'
+    const vehicleId = 'veh-active'
+
+    mockFindById.mockResolvedValue({ id: driverId, name: 'Maria Driver' })
+    mockActiveVehicleAssignmentFindByDriver.mockResolvedValue({
+      driver_id: driverId,
+      vehicle_id: vehicleId,
+      session_id: null,
+      acquired_at: new Date(),
+    })
+
+    const { status, body } = await patch(
+      server,
+      `/drivers/${driverId}/vehicles/${vehicleId}`,
+      { selectable: false },
+      VALID_AUTH_HEADERS
+    )
+
+    expect(status).toBe(409)
+    expect(body.error).toBe('vehicle_active')
+    expect(body.held_by).toEqual({ id: driverId, name: 'Maria Driver' })
+    expect(mockForceDisconnect).not.toHaveBeenCalled()
+    expect(mockDriverVehicleSetSelectable).not.toHaveBeenCalled()
+  })
+
+  it('calls forceDisconnect and returns 200 when setting selectable=false with confirmed=true and active assignment', async () => {
+    const driverId = 'drv-1'
+    const vehicleId = 'veh-active'
+
+    mockFindById.mockResolvedValue({ id: driverId, name: 'Maria Driver' })
+    mockActiveVehicleAssignmentFindByDriver.mockResolvedValue({
+      driver_id: driverId,
+      vehicle_id: vehicleId,
+      session_id: null,
+      acquired_at: new Date(),
+    })
+    mockDriverVehicleSetSelectable.mockResolvedValue(undefined)
+    mockDriverRecordFindByPk.mockResolvedValue({
+      get: (_opts: any) => ({ selected_vehicle_id: vehicleId }),
+    })
+    mockAutoPromoteSelectedVehicle.mockResolvedValue(undefined)
+
+    const { status, body } = await patch(
+      server,
+      `/drivers/${driverId}/vehicles/${vehicleId}`,
+      { selectable: false, confirmed: true },
+      VALID_AUTH_HEADERS
+    )
+
+    expect(status).toBe(200)
+    expect(body.success).toBe(true)
+    expect(mockForceDisconnect).toHaveBeenCalledTimes(1)
+    expect(mockForceDisconnect).toHaveBeenCalledWith(driverId, 'vehicle_not_selectable')
+    expect(mockDriverVehicleSetSelectable).toHaveBeenCalledWith(driverId, vehicleId, false)
+  })
+
+  it('does NOT call forceDisconnect when driver has a different vehicle active (not the one being toggled)', async () => {
+    const driverId = 'drv-1'
+    const vehicleId = 'veh-other'
+
+    mockFindById.mockResolvedValue({ id: driverId, name: 'Test Driver' })
+    mockActiveVehicleAssignmentFindByDriver.mockResolvedValue({
+      driver_id: driverId,
+      vehicle_id: 'veh-different',
+      session_id: null,
+      acquired_at: new Date(),
+    })
+    mockDriverVehicleSetSelectable.mockResolvedValue(undefined)
+    mockDriverRecordFindByPk.mockResolvedValue({
+      get: (_opts: any) => ({ selected_vehicle_id: 'veh-selected' }),
+    })
+
+    const { status, body } = await patch(
+      server,
+      `/drivers/${driverId}/vehicles/${vehicleId}`,
+      { selectable: false },
+      VALID_AUTH_HEADERS
+    )
+
+    expect(status).toBe(200)
+    expect(body.success).toBe(true)
+    expect(mockForceDisconnect).not.toHaveBeenCalled()
+    expect(mockDriverVehicleSetSelectable).toHaveBeenCalledWith(driverId, vehicleId, false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// POST /drivers/:id/vehicles — find-or-create reuse without overwriting fields
+// ---------------------------------------------------------------------------
+
+describe('POST /drivers/:id/vehicles (find-or-create reuse)', () => {
+  it('reuses existing vehicle row when plate already exists and does not overwrite brand', async () => {
+    const driverId = 'drv-1'
+    const existingVehicleId = 'veh-existing'
+
+    mockFindById.mockResolvedValue({ id: driverId, name: 'Test Driver' })
+    // findOrCreateByPlate returns the existing vehicle (brand is the original one, not the one sent)
+    const existingVehicle = {
+      id: existingVehicleId,
+      plate: 'ABC123',
+      brand: 'OriginalBrand',
+      model: null,
+      color: null,
+      enabled: true,
+      created_at: new Date(),
+      updated_at: new Date(),
+    }
+    mockFindOrCreateByPlate.mockResolvedValue(existingVehicle)
+    mockDriverVehicleLink.mockResolvedValue(undefined)
+    // DriverRecord.findByPk returns driver with a non-null selected_vehicle_id (so no auto-set)
+    mockDriverRecordFindByPk.mockResolvedValue({
+      get: (_opts: any) => ({ selected_vehicle_id: 'some-other-vehicle' }),
+    })
+
+    const { status, body } = await post(
+      server,
+      `/drivers/${driverId}/vehicles`,
+      { vehicle: { plate: 'ABC123', brand: 'OtherBrand' } },
+      VALID_AUTH_HEADERS
+    )
+
+    expect(status).toBe(201)
+    expect(body.success).toBe(true)
+    expect(body.data.vehicle_id).toBe(existingVehicleId)
+    // findOrCreateByPlate was called with the plate and full payload (brand included)
+    // but since the vehicle already exists it returns the existing record unmodified
+    expect(mockFindOrCreateByPlate).toHaveBeenCalledTimes(1)
+    expect(mockFindOrCreateByPlate).toHaveBeenCalledWith(
+      'ABC123',
+      { plate: 'ABC123', brand: 'OtherBrand' },
+      mockTransaction
+    )
+    // link was created for the existing vehicle
+    expect(mockDriverVehicleLink).toHaveBeenCalledWith(driverId, existingVehicleId, mockTransaction)
+    // the returned vehicle_id is the existing one (not a new one)
+    expect(body.data.vehicle_id).toBe(existingVehicleId)
+  })
+
+  it('sets selected_vehicle_id when driver has no selected vehicle yet', async () => {
+    const driverId = 'drv-1'
+    const newVehicleId = 'veh-new'
+
+    mockFindById.mockResolvedValue({ id: driverId, name: 'Test Driver' })
+    mockFindOrCreateByPlate.mockResolvedValue({
+      id: newVehicleId,
+      plate: 'XYZ789',
+      brand: 'Toyota',
+    })
+    mockDriverVehicleLink.mockResolvedValue(undefined)
+    // DriverRecord.findByPk returns driver with selected_vehicle_id = null
+    mockDriverRecordFindByPk.mockResolvedValue({
+      get: (_opts: any) => ({ selected_vehicle_id: null }),
+    })
+    mockDriverRecordUpdate.mockResolvedValue(undefined)
+
+    const { status, body } = await post(
+      server,
+      `/drivers/${driverId}/vehicles`,
+      { vehicle: { plate: 'XYZ789', brand: 'Toyota' } },
+      VALID_AUTH_HEADERS
+    )
+
+    expect(status).toBe(201)
+    expect(body.success).toBe(true)
+    // selected_vehicle_id was set to the new vehicle
+    expect(mockDriverRecordUpdate).toHaveBeenCalledTimes(1)
+    const [updateData] = mockDriverRecordUpdate.mock.calls[0]
+    expect(updateData.selected_vehicle_id).toBe(newVehicleId)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// POST /drivers/:id/selected-vehicle — rejection of ineligible vehicles
+// ---------------------------------------------------------------------------
+
+describe('POST /drivers/:id/selected-vehicle (ineligible vehicle rejection)', () => {
+  it('returns 400 with error=vehicle_not_eligible when vehicleId is not in eligible list', async () => {
+    const driverId = 'drv-1'
+
+    mockFindById.mockResolvedValue({ id: driverId, name: 'Test Driver' })
+    // eligible list does NOT contain v-ineligible
+    mockDriverVehicleFindEligibleForDriver.mockResolvedValue([
+      { vehicle_id: 'veh-eligible', selectable: true, vehicle: { enabled: true } },
+    ])
+
+    const { status, body } = await post(
+      server,
+      `/drivers/${driverId}/selected-vehicle`,
+      { vehicleId: 'v-ineligible' },
+      VALID_AUTH_HEADERS
+    )
+
+    expect(status).toBe(400)
+    expect(body.error).toBe('vehicle_not_eligible')
+    expect(mockDriverRecordUpdate).not.toHaveBeenCalled()
+  })
+
+  it('returns 200 when vehicleId is in the eligible list', async () => {
+    const driverId = 'drv-1'
+    const eligibleVehicleId = 'veh-eligible'
+
+    mockFindById.mockResolvedValue({ id: driverId, name: 'Test Driver' })
+    mockDriverVehicleFindEligibleForDriver.mockResolvedValue([
+      { vehicle_id: eligibleVehicleId, selectable: true, vehicle: { enabled: true } },
+    ])
+    mockDriverRecordUpdate.mockResolvedValue(undefined)
+
+    const { status, body } = await post(
+      server,
+      `/drivers/${driverId}/selected-vehicle`,
+      { vehicleId: eligibleVehicleId },
+      VALID_AUTH_HEADERS
+    )
+
+    expect(status).toBe(200)
+    expect(body.success).toBe(true)
+    expect(mockDriverRecordUpdate).toHaveBeenCalledTimes(1)
+    const [updateData] = mockDriverRecordUpdate.mock.calls[0]
+    expect(updateData.selected_vehicle_id).toBe(eligibleVehicleId)
+  })
+
+  it('returns 404 when driver is not found', async () => {
+    mockFindById.mockResolvedValue(null)
+
+    const { status, body } = await post(
+      server,
+      '/drivers/nonexistent/selected-vehicle',
+      { vehicleId: 'veh-1' },
+      VALID_AUTH_HEADERS
+    )
+
+    expect(status).toBe(404)
+    expect(body.success).toBe(false)
+    expect(mockDriverVehicleFindEligibleForDriver).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// POST /drivers — create driver (new shape and legacy shape)
+// ---------------------------------------------------------------------------
+
+describe('POST /drivers (DriversController)', () => {
+  const createdDriver = {
+    id: 'drv-new',
+    name: 'John Doe',
+    email: 'john@example.com',
+    phone: '555-1234',
+    docType: 'cc',
+    document: '123456',
+    paymentMode: 'monthly',
+    balance: 0,
+    enabled_at: 0,
+    created_at: 0,
+    last_connection: 0,
+    vehicle: {},
+  }
+
+  it('creates driver using new shape { driver, vehicle }', async () => {
+    mockStore.mockResolvedValue(createdDriver)
+    mockFindOrCreateByPlate.mockResolvedValue({ id: 'veh-1', plate: 'ABC123' })
+    mockDriverVehicleLink.mockResolvedValue(undefined)
+    mockDriverRecordUpdate.mockResolvedValue(undefined)
+
+    const { status, body } = await post(
+      server,
+      '/drivers',
+      { driver: { name: 'John Doe' }, vehicle: { plate: 'ABC123' } },
+      VALID_AUTH_HEADERS
+    )
+
+    expect(status).toBe(201)
+    expect(body.success).toBe(true)
+    expect(mockStore).toHaveBeenCalledWith({ name: 'John Doe' })
+    expect(mockFindOrCreateByPlate).toHaveBeenCalledWith('ABC123', { plate: 'ABC123' })
+    expect(mockDriverVehicleLink).toHaveBeenCalledWith('drv-new', 'veh-1')
+    expect(mockDriverRecordUpdate).toHaveBeenCalledTimes(1)
+  })
+
+  it('creates driver using new shape with { vehicleId } — links by id without find-or-create', async () => {
+    mockStore.mockResolvedValue(createdDriver)
+    mockDriverVehicleLink.mockResolvedValue(undefined)
+    mockDriverRecordUpdate.mockResolvedValue(undefined)
+
+    const { status, body } = await post(
+      server,
+      '/drivers',
+      { driver: { name: 'John Doe' }, vehicle: { vehicleId: 'veh-existing' } },
+      VALID_AUTH_HEADERS
+    )
+
+    expect(status).toBe(201)
+    expect(body.success).toBe(true)
+    expect(mockFindOrCreateByPlate).not.toHaveBeenCalled()
+    expect(mockDriverVehicleLink).toHaveBeenCalledWith('drv-new', 'veh-existing')
+  })
+
+  it('creates driver using legacy inline shape and logs deprecation', async () => {
+    const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    mockStore.mockResolvedValue(createdDriver)
+
+    const { status, body } = await post(
+      server,
+      '/drivers',
+      { name: 'John Doe', email: 'john@example.com' },
+      VALID_AUTH_HEADERS
+    )
+
+    expect(status).toBe(201)
+    expect(body.success).toBe(true)
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('[DEPRECATED]'))
+    consoleSpy.mockRestore()
+  })
+
+  it('creates driver without vehicle payload — no link is created', async () => {
+    mockStore.mockResolvedValue(createdDriver)
+
+    const { status, body } = await post(
+      server,
+      '/drivers',
+      { driver: { name: 'John Doe' } },
+      VALID_AUTH_HEADERS
+    )
+
+    expect(status).toBe(201)
+    expect(body.success).toBe(true)
+    expect(mockDriverVehicleLink).not.toHaveBeenCalled()
+    expect(mockFindOrCreateByPlate).not.toHaveBeenCalled()
+  })
+
+  it('calls Store.refreshDrivers() after creating a driver', async () => {
+    mockStore.mockResolvedValue(createdDriver)
+
+    await post(server, '/drivers', { driver: { name: 'John Doe' } }, VALID_AUTH_HEADERS)
+
+    expect(mockRefreshDrivers).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// PUT /drivers/:id — update driver (new shape and legacy shape)
+// ---------------------------------------------------------------------------
+
+describe('PUT /drivers/:id (DriversController)', () => {
+  const updatedDriver = {
+    id: 'drv-1',
+    name: 'Jane Doe',
+    email: 'jane@example.com',
+    phone: '555-5678',
+    docType: 'cc',
+    document: '654321',
+    paymentMode: 'monthly',
+    balance: 0,
+    enabled_at: 0,
+    created_at: 0,
+    last_connection: 0,
+    vehicle: {},
+  }
+
+  it('updates driver using new shape { driver } and strips vehicle field', async () => {
+    mockStore.mockResolvedValue(updatedDriver)
+
+    const { status, body } = await put(
+      server,
+      '/drivers/drv-1',
+      { driver: { name: 'Jane Doe', vehicle: { plate: 'SHOULD_BE_STRIPPED' } } },
+      VALID_AUTH_HEADERS
+    )
+
+    expect(status).toBe(200)
+    expect(body.success).toBe(true)
+    // vehicle must not be forwarded to store
+    const [storeArg] = mockStore.mock.calls[0]
+    expect(storeArg.vehicle).toBeUndefined()
+    expect(storeArg.id).toBe('drv-1')
+  })
+
+  it('updates driver using legacy inline shape, strips vehicle, and logs deprecation', async () => {
+    const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    mockStore.mockResolvedValue(updatedDriver)
+
+    const { status, body } = await put(
+      server,
+      '/drivers/drv-1',
+      { name: 'Jane Doe', vehicle: { plate: 'OLD_PLATE' } },
+      VALID_AUTH_HEADERS
+    )
+
+    expect(status).toBe(200)
+    expect(body.success).toBe(true)
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('[DEPRECATED]'))
+    const [storeArg] = mockStore.mock.calls[0]
+    expect(storeArg.vehicle).toBeUndefined()
+    consoleSpy.mockRestore()
+  })
+
+  it('calls Store.refreshDrivers() after updating a driver', async () => {
+    mockStore.mockResolvedValue(updatedDriver)
+
+    await put(server, '/drivers/drv-1', { driver: { name: 'Jane Doe' } }, VALID_AUTH_HEADERS)
+
+    expect(mockRefreshDrivers).toHaveBeenCalledTimes(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// GET /drivers/:id — enriched response with selected_vehicle, roster, active_vehicle_id
+// ---------------------------------------------------------------------------
+
+describe('GET /drivers/:id (DriversController)', () => {
+  const baseDriver = {
+    id: 'drv-1',
+    name: 'Test Driver',
+    email: 'driver@test.com',
+    phone: '555-0000',
+    docType: 'cc',
+    document: '111111',
+    paymentMode: 'monthly',
+    balance: 0,
+    enabled_at: 0,
+    created_at: 0,
+    last_connection: 0,
+    vehicle: { plate: 'OLD123' },
+    selected_vehicle_id: 'veh-1',
+  }
+
+  it('returns 404 when driver is not found', async () => {
+    mockFindById.mockResolvedValue(null)
+
+    const { status, body } = await get(server, '/drivers/nonexistent', VALID_AUTH_HEADERS)
+
+    expect(status).toBe(404)
+    expect(body.success).toBe(false)
+  })
+
+  it('returns enriched driver without vehicle field, with selected_vehicle, roster, active_vehicle_id', async () => {
+    mockFindById.mockResolvedValue(baseDriver)
+    mockDriverVehicleListForDriver.mockResolvedValue([
+      { vehicle_id: 'veh-1', selectable: true, vehicle: { id: 'veh-1', plate: 'ABC123' } },
+    ])
+    mockActiveVehicleAssignmentFindByDriver.mockResolvedValue({
+      vehicle_id: 'veh-1',
+      driver_id: 'drv-1',
+      session_id: null,
+      acquired_at: new Date(),
+    })
+    mockVehicleRepoFindById.mockResolvedValue({ id: 'veh-1', plate: 'ABC123', brand: 'Toyota' })
+
+    const { status, body } = await get(server, '/drivers/drv-1', VALID_AUTH_HEADERS)
+
+    expect(status).toBe(200)
+    expect(body.success).toBe(true)
+    const driver = body.data.driver
+    // vehicle JSONB field must be omitted
+    expect(driver.vehicle).toBeUndefined()
+    // new fields must be present
+    expect(driver.selected_vehicle).toEqual({ id: 'veh-1', plate: 'ABC123', brand: 'Toyota' })
+    expect(driver.roster).toHaveLength(1)
+    expect(driver.active_vehicle_id).toBe('veh-1')
+  })
+
+  it('returns selected_vehicle=null when selected_vehicle_id is null', async () => {
+    mockFindById.mockResolvedValue({ ...baseDriver, selected_vehicle_id: null })
+    mockDriverVehicleListForDriver.mockResolvedValue([])
+    mockActiveVehicleAssignmentFindByDriver.mockResolvedValue(null)
+
+    const { status, body } = await get(server, '/drivers/drv-1', VALID_AUTH_HEADERS)
+
+    expect(status).toBe(200)
+    expect(body.data.driver.selected_vehicle).toBeNull()
+    expect(body.data.driver.active_vehicle_id).toBeNull()
+    expect(mockVehicleRepoFindById).not.toHaveBeenCalled()
   })
 })

--- a/src/Api/Controllers/Internal/DriversInternalController.ts
+++ b/src/Api/Controllers/Internal/DriversInternalController.ts
@@ -1,0 +1,76 @@
+import { Request, Response, Router } from 'express'
+import DriverRecord from '../../../Models/DriverRecord'
+import ActiveVehicleAssignmentRepository from '../../../Repositories/ActiveVehicleAssignmentRepository'
+import VehicleRepository from '../../../Repositories/VehicleRepository'
+import { requireInternalAuth } from '../../../Middlewares/Authorization'
+
+const controller = Router()
+const vehicleRepo = new VehicleRepository()
+
+controller.use(requireInternalAuth)
+
+controller.get('/:id/active-vehicle', async (req: Request, res: Response) => {
+  try {
+    const driverId = String(req.params.id ?? '').trim()
+
+    if (!driverId) {
+      return res.status(400).json({
+        success: false,
+        message: 'driver id is required',
+        data: {},
+      })
+    }
+
+    const assignment = await ActiveVehicleAssignmentRepository.findByDriver(driverId)
+    if (assignment) {
+      const vehicle = await vehicleRepo.findById(assignment.vehicle_id)
+      if (vehicle) {
+        return res.status(200).json({
+          success: true,
+          data: {
+            vehicle_id: vehicle.id,
+            plate: vehicle.plate,
+            brand: vehicle.brand,
+            model: vehicle.model,
+            color: vehicle.color,
+          },
+        })
+      }
+    }
+
+    const driverRaw = await DriverRecord.findByPk(driverId)
+    if (!driverRaw) {
+      return res.status(200).json({ success: true, data: { vehicle_id: null } })
+    }
+
+    const selectedVehicleId = (driverRaw.get({ plain: true }) as any)?.selected_vehicle_id ?? null
+    if (!selectedVehicleId) {
+      return res.status(200).json({ success: true, data: { vehicle_id: null } })
+    }
+
+    const vehicle = await vehicleRepo.findById(selectedVehicleId)
+    if (!vehicle) {
+      return res.status(200).json({ success: true, data: { vehicle_id: null } })
+    }
+
+    return res.status(200).json({
+      success: true,
+      data: {
+        vehicle_id: vehicle.id,
+        plate: vehicle.plate,
+        brand: vehicle.brand,
+        model: vehicle.model,
+        color: vehicle.color,
+      },
+    })
+  } catch (error) {
+    console.error('Error fetching driver active vehicle:', error)
+    return res.status(500).json({
+      success: false,
+      message: 'Internal server error',
+      data: {},
+    })
+  }
+})
+
+export default controller

--- a/src/Api/Controllers/Vehicles/VehiclesController.ts
+++ b/src/Api/Controllers/Vehicles/VehiclesController.ts
@@ -1,0 +1,307 @@
+import { Request, Response, Router } from 'express'
+import { requireAuth } from '../../../Middlewares/Authorization'
+import VehicleRepository, { VehicleSearchQuery } from '../../../Repositories/VehicleRepository'
+import ActiveVehicleAssignmentRepository from '../../../Repositories/ActiveVehicleAssignmentRepository'
+import { normalizePlate } from '../../../Helpers/PlateHelper'
+import sequelize from '../../../Database/sequelize'
+import { QueryTypes } from 'sequelize'
+import { forceDisconnect } from '../../../Services/drivers/ForceDisconnect'
+import { autoPromoteSelectedVehicle } from '../../../Services/drivers/AutoPromoteVehicle'
+
+const controller = Router()
+const vehicleRepo = new VehicleRepository()
+
+controller.use(requireAuth)
+
+const ALLOWED_PER_PAGE = [20, 30, 50]
+
+// GET /vehicles
+controller.get('/', async (req: Request, res: Response) => {
+  try {
+    const { search, enabled, sort, page, perPage } = req.query
+
+    if (perPage !== undefined) {
+      const perPageNum = Number(perPage)
+      if (!ALLOWED_PER_PAGE.includes(perPageNum)) {
+        return res.status(400).json({
+          success: false,
+          message: `Invalid perPage value. Allowed values: ${ALLOWED_PER_PAGE.join(', ')}`,
+          data: {},
+        })
+      }
+    }
+
+    const pageNum = Math.max(1, parseInt(String(page ?? '1'), 10) || 1)
+
+    let enabledFilter: boolean | undefined = undefined
+    if (enabled !== undefined) {
+      enabledFilter = enabled === 'true' || enabled === '1'
+    }
+
+    const query: VehicleSearchQuery = {
+      search: search !== undefined ? String(search) : undefined,
+      enabled: enabledFilter,
+      sort: sort !== undefined ? String(sort) : undefined,
+      page: pageNum,
+      perPage: perPage !== undefined ? Number(perPage) : undefined,
+    }
+
+    const { vehicles, total } = await vehicleRepo.search(query)
+    return res.status(200).json({
+      success: true,
+      data: { vehicles, total },
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Internal server error'
+    if (message.startsWith('Invalid sort field')) {
+      return res.status(400).json({ success: false, message, data: {} })
+    }
+    console.error('Error fetching vehicles:', error)
+    return res.status(500).json({
+      success: false,
+      message: 'Internal server error',
+      data: {},
+    })
+  }
+})
+
+// GET /vehicles/lookup?plate= — must be registered BEFORE GET /vehicles/:id
+controller.get('/lookup', async (req: Request, res: Response) => {
+  try {
+    const { plate } = req.query
+    if (!plate || typeof plate !== 'string') {
+      return res.status(400).json({
+        success: false,
+        message: 'plate query parameter is required',
+        data: {},
+      })
+    }
+
+    const normalized = normalizePlate(plate)
+    const vehicle = await vehicleRepo.findByNormalizedPlate(normalized)
+    if (!vehicle) {
+      return res.status(404).json({ error: 'vehicle_not_found' })
+    }
+
+    const vehicleWithDrivers = await vehicleRepo.findWithLinkedDrivers(vehicle.id)
+
+    const assignment = await ActiveVehicleAssignmentRepository.findByVehicle(vehicle.id)
+    let currently_driven_by: { id: string; name: string } | null = null
+    if (assignment) {
+      const rows = await sequelize.query<{ id: string; name: string }>(
+        `SELECT id, name FROM drivers WHERE id = :driverId LIMIT 1`,
+        { replacements: { driverId: assignment.driver_id }, type: QueryTypes.SELECT }
+      )
+      if (rows.length > 0) {
+        currently_driven_by = { id: rows[0].id, name: rows[0].name }
+      }
+    }
+
+    return res.status(200).json({
+      success: true,
+      data: {
+        vehicle: vehicleWithDrivers ?? vehicle,
+        linked_drivers: vehicleWithDrivers?.linked_drivers ?? [],
+        currently_driven_by,
+      },
+    })
+  } catch (error) {
+    console.error('Error looking up vehicle:', error)
+    return res.status(500).json({
+      success: false,
+      message: 'Internal server error',
+      data: {},
+    })
+  }
+})
+
+// GET /vehicles/:id
+controller.get('/:id', async (req: Request, res: Response) => {
+  try {
+    const vehicleWithDrivers = await vehicleRepo.findWithLinkedDrivers(req.params.id)
+    if (!vehicleWithDrivers) {
+      return res.status(404).json({
+        success: false,
+        message: 'Vehicle not found',
+        data: {},
+      })
+    }
+
+    return res.status(200).json({
+      success: true,
+      data: { vehicle: vehicleWithDrivers, linked_drivers: vehicleWithDrivers.linked_drivers },
+    })
+  } catch (error) {
+    console.error('Error fetching vehicle:', error)
+    return res.status(500).json({
+      success: false,
+      message: 'Internal server error',
+      data: {},
+    })
+  }
+})
+
+// POST /vehicles
+controller.post('/', async (req: Request, res: Response) => {
+  try {
+    const { plate, brand, model, color, photo_url, soat_exp, tec_exp } = req.body
+
+    if (!plate || typeof plate !== 'string') {
+      return res.status(400).json({
+        success: false,
+        message: 'plate is required',
+        data: {},
+      })
+    }
+
+    if (!brand || typeof brand !== 'string' || brand.trim() === '') {
+      return res.status(400).json({ success: false, message: 'brand is required', data: {} })
+    }
+
+    if (!model || typeof model !== 'string' || model.trim() === '') {
+      return res.status(400).json({ success: false, message: 'model is required', data: {} })
+    }
+
+    if (!color || typeof color !== 'object' || Array.isArray(color) || typeof color.name !== 'string' || color.name.trim() === '') {
+      return res.status(400).json({ error: 'color_invalid' })
+    }
+
+    const normalizedPlate = normalizePlate(plate)
+
+    const existing = await vehicleRepo.findByNormalizedPlate(normalizedPlate)
+    if (existing) {
+      return res.status(409).json({
+        error: 'plate_already_exists',
+        vehicle_id: existing.id,
+      })
+    }
+
+    const vehicle = await vehicleRepo.create({
+      plate: normalizedPlate,
+      brand: brand ?? null,
+      model: model ?? null,
+      color: color ?? null,
+      photo_url: photo_url ?? null,
+      soat_exp: soat_exp ?? null,
+      tec_exp: tec_exp ?? null,
+    })
+
+    return res.status(201).json({
+      success: true,
+      data: { vehicle },
+    })
+  } catch (error) {
+    console.error('Error creating vehicle:', error)
+    return res.status(500).json({
+      success: false,
+      message: 'Internal server error',
+      data: {},
+    })
+  }
+})
+
+// PATCH /vehicles/:id
+controller.patch('/:id', async (req: Request, res: Response) => {
+  if ('plate' in req.body) {
+    return res.status(400).json({ error: 'plate_immutable' })
+  }
+
+  try {
+    const vehicle = await vehicleRepo.findById(req.params.id)
+    if (!vehicle) {
+      return res.status(404).json({
+        success: false,
+        message: 'Vehicle not found',
+        data: {},
+      })
+    }
+
+    const { color } = req.body
+    if (color !== undefined && color !== null) {
+      if (typeof color !== 'object' || Array.isArray(color) || typeof color.name !== 'string') {
+        return res.status(400).json({ error: 'color_invalid' })
+      }
+    }
+
+    await vehicleRepo.update(req.params.id, req.body)
+
+    const updated = await vehicleRepo.findById(req.params.id)
+    return res.status(200).json({
+      success: true,
+      data: { vehicle: updated },
+    })
+  } catch (error) {
+    console.error('Error updating vehicle:', error)
+    return res.status(500).json({
+      success: false,
+      message: 'Internal server error',
+      data: {},
+    })
+  }
+})
+
+// PATCH /vehicles/:id/enabled
+controller.patch('/:id/enabled', async (req: Request, res: Response) => {
+  try {
+    const { enabled, confirmed } = req.body
+    if (typeof enabled !== 'boolean') {
+      return res.status(400).json({
+        success: false,
+        message: 'enabled must be a boolean',
+        data: {},
+      })
+    }
+
+    const vehicle = await vehicleRepo.findById(req.params.id)
+    if (!vehicle) {
+      return res.status(404).json({
+        success: false,
+        message: 'Vehicle not found',
+        data: {},
+      })
+    }
+
+    if (!enabled) {
+      const assignment = await ActiveVehicleAssignmentRepository.findByVehicle(req.params.id)
+      if (assignment) {
+        if (confirmed !== true) {
+          const rows = await sequelize.query<{ id: string; name: string }>(
+            `SELECT id, name FROM drivers WHERE id = :driverId LIMIT 1`,
+            { replacements: { driverId: assignment.driver_id }, type: QueryTypes.SELECT }
+          )
+          const held_by =
+            rows.length > 0
+              ? { id: rows[0].id, name: rows[0].name }
+              : { id: assignment.driver_id, name: '' }
+          return res.status(409).json({ error: 'vehicle_active', held_by })
+        }
+        await forceDisconnect(assignment.driver_id, 'vehicle_disabled')
+      }
+    }
+
+    await vehicleRepo.setEnabled(req.params.id, enabled)
+
+    if (!enabled) {
+      const affectedDrivers = await sequelize.query<{ id: string }>(
+        `SELECT id FROM drivers WHERE selected_vehicle_id = :vehicleId`,
+        { replacements: { vehicleId: req.params.id }, type: QueryTypes.SELECT }
+      )
+      await Promise.all(affectedDrivers.map((d) => autoPromoteSelectedVehicle(d.id)))
+    }
+
+    const updated = await vehicleRepo.findById(req.params.id)
+    return res.status(200).json({
+      success: true,
+      data: { vehicle: updated },
+    })
+  } catch (error) {
+    console.error('Error updating vehicle enabled state:', error)
+    return res.status(500).json({
+      success: false,
+      message: 'Internal server error',
+      data: {},
+    })
+  }
+})
+
+export default controller

--- a/src/Api/Controllers/Vehicles/VehiclesController.ts
+++ b/src/Api/Controllers/Vehicles/VehiclesController.ts
@@ -1,6 +1,9 @@
 import { Request, Response, Router } from 'express'
 import { requireAuth } from '../../../Middlewares/Authorization'
-import VehicleRepository, { VehicleSearchQuery } from '../../../Repositories/VehicleRepository'
+import VehicleRepository, {
+  VehicleSearchQuery,
+  getMissingVehicleFields,
+} from '../../../Repositories/VehicleRepository'
 import ActiveVehicleAssignmentRepository from '../../../Repositories/ActiveVehicleAssignmentRepository'
 import { normalizePlate } from '../../../Helpers/PlateHelper'
 import sequelize from '../../../Database/sequelize'
@@ -144,7 +147,7 @@ controller.get('/:id', async (req: Request, res: Response) => {
 // POST /vehicles
 controller.post('/', async (req: Request, res: Response) => {
   try {
-    const { plate, brand, model, color, photo_url, soat_exp, tec_exp } = req.body
+    const { plate, brand, model, color, photoUrl, soat_exp, tec_exp } = req.body
 
     if (!plate || typeof plate !== 'string') {
       return res.status(400).json({
@@ -162,7 +165,13 @@ controller.post('/', async (req: Request, res: Response) => {
       return res.status(400).json({ success: false, message: 'model is required', data: {} })
     }
 
-    if (!color || typeof color !== 'object' || Array.isArray(color) || typeof color.name !== 'string' || color.name.trim() === '') {
+    if (
+      !color ||
+      typeof color !== 'object' ||
+      Array.isArray(color) ||
+      typeof color.name !== 'string' ||
+      color.name.trim() === ''
+    ) {
       return res.status(400).json({ error: 'color_invalid' })
     }
 
@@ -181,7 +190,7 @@ controller.post('/', async (req: Request, res: Response) => {
       brand: brand ?? null,
       model: model ?? null,
       color: color ?? null,
-      photo_url: photo_url ?? null,
+      photoUrl: photoUrl ?? null,
       soat_exp: soat_exp ?? null,
       tec_exp: tec_exp ?? null,
     })
@@ -216,14 +225,22 @@ controller.patch('/:id', async (req: Request, res: Response) => {
       })
     }
 
-    const { color } = req.body
+    const { brand, model, color, soat_exp, tec_exp, photoUrl } = req.body
     if (color !== undefined && color !== null) {
       if (typeof color !== 'object' || Array.isArray(color) || typeof color.name !== 'string') {
         return res.status(400).json({ error: 'color_invalid' })
       }
     }
 
-    await vehicleRepo.update(req.params.id, req.body)
+    const updatePayload: Record<string, unknown> = {}
+    if (brand !== undefined) updatePayload.brand = brand
+    if (model !== undefined) updatePayload.model = model
+    if (color !== undefined) updatePayload.color = color
+    if (soat_exp !== undefined) updatePayload.soat_exp = soat_exp
+    if (tec_exp !== undefined) updatePayload.tec_exp = tec_exp
+    if (photoUrl !== undefined) updatePayload.photoUrl = photoUrl
+
+    await vehicleRepo.update(req.params.id, updatePayload as any)
 
     const updated = await vehicleRepo.findById(req.params.id)
     return res.status(200).json({
@@ -259,6 +276,13 @@ controller.patch('/:id/enabled', async (req: Request, res: Response) => {
         message: 'Vehicle not found',
         data: {},
       })
+    }
+
+    if (enabled) {
+      const missingFields = getMissingVehicleFields(vehicle)
+      if (missingFields.length > 0) {
+        return res.status(422).json({ error: 'vehicle_incomplete', missing_fields: missingFields })
+      }
     }
 
     if (!enabled) {

--- a/src/Api/Controllers/Vehicles/VehiclesController.ts
+++ b/src/Api/Controllers/Vehicles/VehiclesController.ts
@@ -18,6 +18,52 @@ controller.use(requireAuth)
 
 const ALLOWED_PER_PAGE = [20, 30, 50]
 
+function normalizeOptionalVehicleDateInput(value: unknown): Date | null | undefined {
+  if (value === undefined) {
+    return undefined
+  }
+
+  if (value === null) {
+    return null
+  }
+
+  if (typeof value === 'string') {
+    const trimmedValue = value.trim()
+    if (trimmedValue === '' || trimmedValue.toLowerCase() === 'invalid date') {
+      return null
+    }
+
+    const parsedDate = /^\d{4}-\d{2}-\d{2}$/.test(trimmedValue)
+      ? new Date(`${trimmedValue}T00:00:00.000Z`)
+      : new Date(trimmedValue)
+    return Number.isNaN(parsedDate.getTime()) ? null : parsedDate
+  }
+
+  if (typeof value === 'number' || value instanceof Date) {
+    const parsedDate = new Date(value)
+    return Number.isNaN(parsedDate.getTime()) ? null : parsedDate
+  }
+
+  return null
+}
+
+function normalizeOptionalPhotoUrl(value: unknown): string | null | undefined {
+  if (value === undefined) {
+    return undefined
+  }
+
+  if (value === null) {
+    return null
+  }
+
+  if (typeof value === 'string') {
+    const trimmedValue = value.trim()
+    return trimmedValue === '' ? null : trimmedValue
+  }
+
+  return null
+}
+
 // GET /vehicles
 controller.get('/', async (req: Request, res: Response) => {
   try {
@@ -148,6 +194,9 @@ controller.get('/:id', async (req: Request, res: Response) => {
 controller.post('/', async (req: Request, res: Response) => {
   try {
     const { plate, brand, model, color, photoUrl, soat_exp, tec_exp } = req.body
+    const normalizedPhotoUrl = normalizeOptionalPhotoUrl(photoUrl)
+    const normalizedSoatExp = normalizeOptionalVehicleDateInput(soat_exp)
+    const normalizedTecExp = normalizeOptionalVehicleDateInput(tec_exp)
 
     if (!plate || typeof plate !== 'string') {
       return res.status(400).json({
@@ -190,9 +239,9 @@ controller.post('/', async (req: Request, res: Response) => {
       brand: brand ?? null,
       model: model ?? null,
       color: color ?? null,
-      photoUrl: photoUrl ?? null,
-      soat_exp: soat_exp ?? null,
-      tec_exp: tec_exp ?? null,
+      photoUrl: normalizedPhotoUrl ?? null,
+      soat_exp: normalizedSoatExp ?? null,
+      tec_exp: normalizedTecExp ?? null,
     })
 
     return res.status(201).json({
@@ -226,6 +275,9 @@ controller.patch('/:id', async (req: Request, res: Response) => {
     }
 
     const { brand, model, color, soat_exp, tec_exp, photoUrl } = req.body
+    const normalizedPhotoUrl = normalizeOptionalPhotoUrl(photoUrl)
+    const normalizedSoatExp = normalizeOptionalVehicleDateInput(soat_exp)
+    const normalizedTecExp = normalizeOptionalVehicleDateInput(tec_exp)
     if (color !== undefined && color !== null) {
       if (typeof color !== 'object' || Array.isArray(color) || typeof color.name !== 'string') {
         return res.status(400).json({ error: 'color_invalid' })
@@ -236,9 +288,9 @@ controller.patch('/:id', async (req: Request, res: Response) => {
     if (brand !== undefined) updatePayload.brand = brand
     if (model !== undefined) updatePayload.model = model
     if (color !== undefined) updatePayload.color = color
-    if (soat_exp !== undefined) updatePayload.soat_exp = soat_exp
-    if (tec_exp !== undefined) updatePayload.tec_exp = tec_exp
-    if (photoUrl !== undefined) updatePayload.photoUrl = photoUrl
+    if (normalizedSoatExp !== undefined) updatePayload.soat_exp = normalizedSoatExp
+    if (normalizedTecExp !== undefined) updatePayload.tec_exp = normalizedTecExp
+    if (normalizedPhotoUrl !== undefined) updatePayload.photoUrl = normalizedPhotoUrl
 
     await vehicleRepo.update(req.params.id, updatePayload as any)
 

--- a/src/Api/Controllers/Vehicles/__tests__/VehiclesController.spec.ts
+++ b/src/Api/Controllers/Vehicles/__tests__/VehiclesController.spec.ts
@@ -394,6 +394,68 @@ describe('PATCH /vehicles/:id (update)', () => {
     expect(status).toBe(200)
     expect(body.success).toBe(true)
   })
+
+  it('forwards photoUrl on patch updates', async () => {
+    mockFindById.mockResolvedValue({
+      id: 'veh-1',
+      plate: 'ABC123',
+      brand: 'Mazda',
+      model: '3',
+      color: { name: 'Blue', hex: '#0000ff' },
+      photoUrl: null,
+      soat_exp: null,
+      tec_exp: null,
+      enabled: true,
+      created_at: new Date(),
+      updated_at: new Date(),
+    })
+    mockUpdate.mockResolvedValue(undefined)
+
+    const { status, body } = await patch(server, '/vehicles/veh-1', {
+      photoUrl: 'https://img.example/vehicle.png',
+    })
+
+    expect(status).toBe(200)
+    expect(body.success).toBe(true)
+    expect(mockUpdate).toHaveBeenCalledWith(
+      'veh-1',
+      expect.objectContaining({
+        photoUrl: 'https://img.example/vehicle.png',
+      })
+    )
+  })
+
+  it('normalizes empty and invalid nullable date payloads before update', async () => {
+    mockFindById.mockResolvedValue({
+      id: 'veh-1',
+      plate: 'ABC123',
+      brand: 'Mazda',
+      model: '3',
+      color: { name: 'Blue', hex: '#0000ff' },
+      photoUrl: null,
+      soat_exp: new Date('2026-01-01'),
+      tec_exp: new Date('2026-02-01'),
+      enabled: true,
+      created_at: new Date(),
+      updated_at: new Date(),
+    })
+    mockUpdate.mockResolvedValue(undefined)
+
+    const { status, body } = await patch(server, '/vehicles/veh-1', {
+      soat_exp: '',
+      tec_exp: 'Invalid date',
+    })
+
+    expect(status).toBe(200)
+    expect(body.success).toBe(true)
+    expect(mockUpdate).toHaveBeenCalledWith(
+      'veh-1',
+      expect.objectContaining({
+        soat_exp: null,
+        tec_exp: null,
+      })
+    )
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/src/Api/Controllers/Vehicles/__tests__/VehiclesController.spec.ts
+++ b/src/Api/Controllers/Vehicles/__tests__/VehiclesController.spec.ts
@@ -1,0 +1,527 @@
+import http from 'http'
+import express from 'express'
+import type { AddressInfo } from 'net'
+
+// --- Module mocks (hoisted) ---
+
+jest.mock('../../../../Middlewares/Authorization', () => ({
+  requireAuth: jest.fn((_req: any, _res: any, next: any) => next()),
+}))
+
+jest.mock('../../../../Database/sequelize', () => ({
+  define: jest.fn(),
+  query: jest.fn(),
+}))
+
+// VehicleRepository is a class instantiated at module level in VehiclesController.
+// Mock the whole module so no DB connections occur.
+const mockSearch = jest.fn()
+const mockFindByNormalizedPlate = jest.fn()
+const mockFindWithLinkedDrivers = jest.fn()
+const mockFindById = jest.fn()
+const mockCreate = jest.fn()
+const mockUpdate = jest.fn()
+const mockSetEnabled = jest.fn()
+
+jest.mock('../../../../Repositories/VehicleRepository', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({
+    search: mockSearch,
+    findByNormalizedPlate: mockFindByNormalizedPlate,
+    findWithLinkedDrivers: mockFindWithLinkedDrivers,
+    findById: mockFindById,
+    create: mockCreate,
+    update: mockUpdate,
+    setEnabled: mockSetEnabled,
+  })),
+}))
+
+// ActiveVehicleAssignmentRepository is a singleton (default export is an instance).
+const mockFindByVehicle = jest.fn()
+jest.mock('../../../../Repositories/ActiveVehicleAssignmentRepository', () => ({
+  __esModule: true,
+  default: {
+    findByVehicle: mockFindByVehicle,
+    acquire: jest.fn(),
+    releaseByDriver: jest.fn(),
+    releaseByVehicle: jest.fn(),
+    findByDriver: jest.fn(),
+  },
+}))
+
+// ForceDisconnect service — mock so no Firebase calls occur in tests.
+const mockForceDisconnect = jest.fn()
+jest.mock('../../../../Services/drivers/ForceDisconnect', () => ({
+  __esModule: true,
+  forceDisconnect: (...args: any[]) => mockForceDisconnect(...args),
+}))
+
+// AutoPromoteVehicle service — mock so no DB calls occur in tests.
+const mockAutoPromoteSelectedVehicle = jest.fn()
+jest.mock('../../../../Services/drivers/AutoPromoteVehicle', () => ({
+  __esModule: true,
+  autoPromoteSelectedVehicle: (...args: any[]) => mockAutoPromoteSelectedVehicle(...args),
+}))
+
+// ---------------------------------------------------------------------------
+// Typed accessors
+// ---------------------------------------------------------------------------
+
+const MockedAuth = jest.requireMock('../../../../Middlewares/Authorization') as {
+  requireAuth: jest.Mock
+}
+
+const MockedSequelize = jest.requireMock('../../../../Database/sequelize') as {
+  query: jest.Mock
+}
+
+// ---------------------------------------------------------------------------
+// HTTP helpers
+// ---------------------------------------------------------------------------
+
+function makeRequest(
+  server: http.Server,
+  method: string,
+  path: string,
+  body?: any,
+  headers: Record<string, string> = {}
+): Promise<{ status: number; body: any }> {
+  return new Promise((resolve, reject) => {
+    const { port } = server.address() as AddressInfo
+    const payload = body !== undefined ? JSON.stringify(body) : undefined
+    const opts: http.RequestOptions = {
+      hostname: '127.0.0.1',
+      port,
+      path,
+      method,
+      headers: {
+        ...(payload
+          ? {
+              'Content-Type': 'application/json',
+              'Content-Length': Buffer.byteLength(payload),
+            }
+          : {}),
+        ...headers,
+      },
+    }
+    const req = http.request(opts, (res) => {
+      let data = ''
+      res.on('data', (chunk) => {
+        data += chunk
+      })
+      res.on('end', () => {
+        try {
+          resolve({ status: res.statusCode ?? 0, body: JSON.parse(data) })
+        } catch {
+          resolve({ status: res.statusCode ?? 0, body: data })
+        }
+      })
+    })
+    req.on('error', reject)
+    if (payload) req.write(payload)
+    req.end()
+  })
+}
+
+function get(
+  server: http.Server,
+  path: string,
+  headers: Record<string, string> = {}
+): Promise<{ status: number; body: any }> {
+  return makeRequest(server, 'GET', path, undefined, headers)
+}
+
+function patch(
+  server: http.Server,
+  path: string,
+  body: any,
+  headers: Record<string, string> = {}
+): Promise<{ status: number; body: any }> {
+  return makeRequest(server, 'PATCH', path, body, headers)
+}
+
+// ---------------------------------------------------------------------------
+// Server setup
+// ---------------------------------------------------------------------------
+
+let server: http.Server
+
+beforeAll((done) => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const controller = require('../VehiclesController').default
+  const app = express()
+  app.use(express.json())
+  app.use('/vehicles', controller)
+  server = http.createServer(app)
+  server.listen(0, '127.0.0.1', done)
+})
+
+afterAll((done) => {
+  server.close(done)
+})
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  MockedAuth.requireAuth.mockImplementation((_req: any, _res: any, next: any) => next())
+  mockForceDisconnect.mockReset()
+  mockForceDisconnect.mockResolvedValue(undefined)
+  mockAutoPromoteSelectedVehicle.mockReset()
+  mockAutoPromoteSelectedVehicle.mockResolvedValue(undefined)
+})
+
+afterEach(() => {
+  jest.restoreAllMocks()
+})
+
+// ---------------------------------------------------------------------------
+// GET /vehicles?search=...
+// ---------------------------------------------------------------------------
+
+describe('GET /vehicles (search)', () => {
+  it('returns 200 with paged vehicles and total', async () => {
+    const fakeVehicle = {
+      id: 'veh-1',
+      plate: 'ABC123',
+      brand: 'Toyota',
+      model: 'Corolla',
+      color: null,
+      photo_url: null,
+      soat_exp: null,
+      tec_exp: null,
+      enabled: true,
+      created_at: new Date(),
+      updated_at: new Date(),
+    }
+    mockSearch.mockResolvedValue({ vehicles: [fakeVehicle], total: 1 })
+
+    const { status, body } = await get(server, '/vehicles?search=Toyota')
+
+    expect(status).toBe(200)
+    expect(body.success).toBe(true)
+    expect(body.data.total).toBe(1)
+    expect(body.data.vehicles).toHaveLength(1)
+    expect(body.data.vehicles[0].plate).toBe('ABC123')
+    expect(mockSearch).toHaveBeenCalledTimes(1)
+    const callArg = mockSearch.mock.calls[0][0]
+    expect(callArg.search).toBe('Toyota')
+  })
+
+  it('returns 200 with empty vehicles when no results', async () => {
+    mockSearch.mockResolvedValue({ vehicles: [], total: 0 })
+
+    const { status, body } = await get(server, '/vehicles?search=NOTFOUND')
+
+    expect(status).toBe(200)
+    expect(body.success).toBe(true)
+    expect(body.data.vehicles).toEqual([])
+    expect(body.data.total).toBe(0)
+  })
+
+  it('returns 400 when perPage is not in allowed set', async () => {
+    const { status, body } = await get(server, '/vehicles?perPage=15')
+
+    expect(status).toBe(400)
+    expect(body.success).toBe(false)
+    expect(body.message).toMatch(/perPage/i)
+    expect(mockSearch).not.toHaveBeenCalled()
+  })
+
+  it('forwards page and perPage to repository', async () => {
+    mockSearch.mockResolvedValue({ vehicles: [], total: 0 })
+
+    await get(server, '/vehicles?page=2&perPage=20')
+
+    const callArg = mockSearch.mock.calls[0][0]
+    expect(callArg.page).toBe(2)
+    expect(callArg.perPage).toBe(20)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// GET /vehicles/lookup?plate=
+// ---------------------------------------------------------------------------
+
+describe('GET /vehicles/lookup (dedupe lookup)', () => {
+  it('returns 200 with vehicle and currently_driven_by when vehicle exists and is assigned', async () => {
+    const fakeVehicle = {
+      id: 'veh-1',
+      plate: 'ABC123',
+      brand: null,
+      model: null,
+      color: null,
+      photo_url: null,
+      soat_exp: null,
+      tec_exp: null,
+      enabled: true,
+      created_at: new Date(),
+      updated_at: new Date(),
+    }
+    const fakeVehicleWithDrivers = { ...fakeVehicle, linked_drivers: [] }
+    const fakeAssignment = {
+      vehicle_id: 'veh-1',
+      driver_id: 'drv-99',
+      session_id: null,
+      acquired_at: new Date(),
+    }
+
+    mockFindByNormalizedPlate.mockResolvedValue(fakeVehicle)
+    mockFindWithLinkedDrivers.mockResolvedValue(fakeVehicleWithDrivers)
+    mockFindByVehicle.mockResolvedValue(fakeAssignment)
+    MockedSequelize.query.mockResolvedValue([{ id: 'drv-99', name: 'Test Driver' }])
+
+    const { status, body } = await get(server, '/vehicles/lookup?plate=ABC123')
+
+    expect(status).toBe(200)
+    expect(body.success).toBe(true)
+    expect(body.data.vehicle.plate).toBe('ABC123')
+    expect(body.data.currently_driven_by).toEqual({ id: 'drv-99', name: 'Test Driver' })
+  })
+
+  it('returns 200 with currently_driven_by=null when vehicle exists but is not assigned', async () => {
+    const fakeVehicle = {
+      id: 'veh-1',
+      plate: 'ABC123',
+      brand: null,
+      model: null,
+      color: null,
+      photo_url: null,
+      soat_exp: null,
+      tec_exp: null,
+      enabled: true,
+      created_at: new Date(),
+      updated_at: new Date(),
+    }
+    const fakeVehicleWithDrivers = { ...fakeVehicle, linked_drivers: [] }
+
+    mockFindByNormalizedPlate.mockResolvedValue(fakeVehicle)
+    mockFindWithLinkedDrivers.mockResolvedValue(fakeVehicleWithDrivers)
+    mockFindByVehicle.mockResolvedValue(null)
+
+    const { status, body } = await get(server, '/vehicles/lookup?plate=ABC123')
+
+    expect(status).toBe(200)
+    expect(body.success).toBe(true)
+    expect(body.data.currently_driven_by).toBeNull()
+  })
+
+  it('normalizes the plate before lookup (lowercase input)', async () => {
+    mockFindByNormalizedPlate.mockResolvedValue(null)
+
+    await get(server, '/vehicles/lookup?plate=abc-123')
+
+    expect(mockFindByNormalizedPlate).toHaveBeenCalledWith('ABC123')
+  })
+
+  it('returns 400 when plate query param is missing', async () => {
+    const { status, body } = await get(server, '/vehicles/lookup')
+
+    expect(status).toBe(400)
+    expect(body.success).toBe(false)
+    expect(body.message).toMatch(/plate/i)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// GET /vehicles/lookup — 404 on miss
+// ---------------------------------------------------------------------------
+
+describe('GET /vehicles/lookup — 404 when vehicle not found', () => {
+  it('returns 404 with error=vehicle_not_found when plate ZZZ does not exist', async () => {
+    mockFindByNormalizedPlate.mockResolvedValue(null)
+
+    const { status, body } = await get(server, '/vehicles/lookup?plate=ZZZ')
+
+    expect(status).toBe(404)
+    expect(body.error).toBe('vehicle_not_found')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// PATCH /vehicles/:id — plate immutability
+// ---------------------------------------------------------------------------
+
+describe('PATCH /vehicles/:id (update)', () => {
+  it('returns 400 with error=plate_immutable when body contains plate', async () => {
+    const { status, body } = await patch(server, '/vehicles/veh-1', {
+      plate: 'NEWPLATE',
+      brand: 'Ford',
+    })
+
+    expect(status).toBe(400)
+    expect(body.error).toBe('plate_immutable')
+    expect(mockUpdate).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 with error=plate_immutable even when plate is undefined as an explicit key', async () => {
+    // Sending `{ plate: undefined }` — JSON encodes it as `{}` so 'plate' is NOT in body.
+    // This test ensures that only an explicit plate key in JSON body triggers rejection.
+    mockFindById.mockResolvedValue({
+      id: 'veh-1',
+      plate: 'ABC123',
+      brand: null,
+      model: null,
+      color: null,
+      photo_url: null,
+      soat_exp: null,
+      tec_exp: null,
+      enabled: true,
+      created_at: new Date(),
+      updated_at: new Date(),
+    })
+
+    const { status, body } = await patch(server, '/vehicles/veh-1', { brand: 'Ford' })
+
+    expect(status).toBe(200)
+    expect(body.success).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// PATCH /vehicles/:id/enabled — toggle enabled
+// ---------------------------------------------------------------------------
+
+describe('PATCH /vehicles/:id/enabled (toggle enabled)', () => {
+  const fakeVehicle = {
+    id: 'veh-1',
+    plate: 'ABC123',
+    brand: null,
+    model: null,
+    color: null,
+    photo_url: null,
+    soat_exp: null,
+    tec_exp: null,
+    enabled: false,
+    created_at: new Date(),
+    updated_at: new Date(),
+  }
+
+  it('returns 200 when enabled=false is sent and vehicle exists with no active assignment', async () => {
+    mockFindById.mockResolvedValue(fakeVehicle)
+    mockSetEnabled.mockResolvedValue(undefined)
+    mockFindByVehicle.mockResolvedValue(null)
+    MockedSequelize.query.mockResolvedValue([])
+
+    const { status, body } = await patch(server, '/vehicles/veh-1/enabled', { enabled: false })
+
+    expect(status).toBe(200)
+    expect(body.success).toBe(true)
+    expect(mockSetEnabled).toHaveBeenCalledWith('veh-1', false)
+  })
+
+  it('returns 200 when enabled=true is sent and vehicle exists', async () => {
+    mockFindById.mockResolvedValue({ ...fakeVehicle, enabled: true })
+    mockSetEnabled.mockResolvedValue(undefined)
+
+    const { status, body } = await patch(server, '/vehicles/veh-1/enabled', { enabled: true })
+
+    expect(status).toBe(200)
+    expect(body.success).toBe(true)
+    expect(mockSetEnabled).toHaveBeenCalledWith('veh-1', true)
+  })
+
+  it('returns 400 when enabled is not a boolean (string value)', async () => {
+    const { status, body } = await patch(server, '/vehicles/veh-1/enabled', { enabled: 'false' })
+
+    expect(status).toBe(400)
+    expect(body.success).toBe(false)
+    expect(body.message).toMatch(/enabled/i)
+    expect(mockSetEnabled).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 when vehicle does not exist', async () => {
+    mockFindById.mockResolvedValue(null)
+
+    const { status, body } = await patch(server, '/vehicles/nonexistent/enabled', {
+      enabled: false,
+    })
+
+    expect(status).toBe(404)
+    expect(body.success).toBe(false)
+    expect(mockSetEnabled).not.toHaveBeenCalled()
+  })
+
+  // ---------------------------------------------------------------------------
+  // Confirmation gate (task 7.3) and force-disconnect (task 7.2)
+  // ---------------------------------------------------------------------------
+
+  it('returns 409 vehicle_active with held_by when disabling a vehicle with an active assignment and no confirmed flag', async () => {
+    const assignment = {
+      vehicle_id: 'veh-1',
+      driver_id: 'drv-99',
+      session_id: null,
+      acquired_at: new Date(),
+    }
+    mockFindById.mockResolvedValue(fakeVehicle)
+    mockFindByVehicle.mockResolvedValue(assignment)
+    // sequelize.query is called to look up driver name
+    MockedSequelize.query.mockResolvedValue([{ id: 'drv-99', name: 'John Doe' }])
+
+    const { status, body } = await patch(server, '/vehicles/veh-1/enabled', { enabled: false })
+
+    expect(status).toBe(409)
+    expect(body.error).toBe('vehicle_active')
+    expect(body.held_by).toEqual({ id: 'drv-99', name: 'John Doe' })
+    expect(mockForceDisconnect).not.toHaveBeenCalled()
+    expect(mockSetEnabled).not.toHaveBeenCalled()
+  })
+
+  it('calls forceDisconnect and returns 200 when disabling an active vehicle with confirmed=true', async () => {
+    const assignment = {
+      vehicle_id: 'veh-1',
+      driver_id: 'drv-99',
+      session_id: null,
+      acquired_at: new Date(),
+    }
+    mockFindById.mockResolvedValue(fakeVehicle)
+    mockFindByVehicle.mockResolvedValue(assignment)
+    mockForceDisconnect.mockResolvedValue(undefined)
+    mockSetEnabled.mockResolvedValue(undefined)
+    // Query for affected drivers (autoPromote pass)
+    MockedSequelize.query.mockResolvedValue([])
+
+    const { status, body } = await patch(server, '/vehicles/veh-1/enabled', {
+      enabled: false,
+      confirmed: true,
+    })
+
+    expect(status).toBe(200)
+    expect(body.success).toBe(true)
+    expect(mockForceDisconnect).toHaveBeenCalledTimes(1)
+    expect(mockForceDisconnect).toHaveBeenCalledWith('drv-99', 'vehicle_disabled')
+    expect(mockSetEnabled).toHaveBeenCalledWith('veh-1', false)
+  })
+
+  it('sends FCM data message with type=force_disconnect and reason=vehicle_disabled shape via forceDisconnect', async () => {
+    // This test validates that forceDisconnect is called with the correct arguments
+    // (i.e. the FCM payload shape is { data: { type: "force_disconnect", reason: "vehicle_disabled" } }).
+    const assignment = {
+      vehicle_id: 'veh-1',
+      driver_id: 'drv-42',
+      session_id: null,
+      acquired_at: new Date(),
+    }
+    mockFindById.mockResolvedValue(fakeVehicle)
+    mockFindByVehicle.mockResolvedValue(assignment)
+    mockForceDisconnect.mockResolvedValue(undefined)
+    mockSetEnabled.mockResolvedValue(undefined)
+    MockedSequelize.query.mockResolvedValue([])
+
+    await patch(server, '/vehicles/veh-1/enabled', { enabled: false, confirmed: true })
+
+    expect(mockForceDisconnect).toHaveBeenCalledWith('drv-42', 'vehicle_disabled')
+  })
+
+  it('runs autoPromoteSelectedVehicle for each driver with selected_vehicle_id equal to the disabled vehicle', async () => {
+    mockFindById.mockResolvedValue(fakeVehicle)
+    mockFindByVehicle.mockResolvedValue(null)
+    mockSetEnabled.mockResolvedValue(undefined)
+    // Two drivers had this vehicle as their selected vehicle
+    MockedSequelize.query.mockResolvedValue([{ id: 'drv-1' }, { id: 'drv-2' }])
+
+    await patch(server, '/vehicles/veh-1/enabled', { enabled: false })
+
+    expect(mockAutoPromoteSelectedVehicle).toHaveBeenCalledTimes(2)
+    expect(mockAutoPromoteSelectedVehicle).toHaveBeenCalledWith('drv-1')
+    expect(mockAutoPromoteSelectedVehicle).toHaveBeenCalledWith('drv-2')
+  })
+})

--- a/src/Api/Controllers/Vehicles/__tests__/VehiclesController.spec.ts
+++ b/src/Api/Controllers/Vehicles/__tests__/VehiclesController.spec.ts
@@ -25,6 +25,26 @@ const mockSetEnabled = jest.fn()
 
 jest.mock('../../../../Repositories/VehicleRepository', () => ({
   __esModule: true,
+  getMissingVehicleFields: (v: any): string[] => {
+    const missing: string[] = []
+    if (!v.brand || typeof v.brand !== 'string' || v.brand.trim() === '') missing.push('brand')
+    if (!v.model || typeof v.model !== 'string' || v.model.trim() === '') missing.push('model')
+    if (!v.color || typeof v.color.name !== 'string' || v.color.name.trim() === '')
+      missing.push('color')
+    if (v.soat_exp == null) missing.push('soat_exp')
+    if (v.tec_exp == null) missing.push('tec_exp')
+    return missing
+  },
+  isVehicleComplete: (v: any): boolean => {
+    const missing: string[] = []
+    if (!v.brand || typeof v.brand !== 'string' || v.brand.trim() === '') missing.push('brand')
+    if (!v.model || typeof v.model !== 'string' || v.model.trim() === '') missing.push('model')
+    if (!v.color || typeof v.color.name !== 'string' || v.color.name.trim() === '')
+      missing.push('color')
+    if (v.soat_exp == null) missing.push('soat_exp')
+    if (v.tec_exp == null) missing.push('tec_exp')
+    return missing.length === 0
+  },
   default: jest.fn().mockImplementation(() => ({
     search: mockSearch,
     findByNormalizedPlate: mockFindByNormalizedPlate,
@@ -185,7 +205,7 @@ describe('GET /vehicles (search)', () => {
       brand: 'Toyota',
       model: 'Corolla',
       color: null,
-      photo_url: null,
+      photoUrl: null,
       soat_exp: null,
       tec_exp: null,
       enabled: true,
@@ -249,7 +269,7 @@ describe('GET /vehicles/lookup (dedupe lookup)', () => {
       brand: null,
       model: null,
       color: null,
-      photo_url: null,
+      photoUrl: null,
       soat_exp: null,
       tec_exp: null,
       enabled: true,
@@ -284,7 +304,7 @@ describe('GET /vehicles/lookup (dedupe lookup)', () => {
       brand: null,
       model: null,
       color: null,
-      photo_url: null,
+      photoUrl: null,
       soat_exp: null,
       tec_exp: null,
       enabled: true,
@@ -361,7 +381,7 @@ describe('PATCH /vehicles/:id (update)', () => {
       brand: null,
       model: null,
       color: null,
-      photo_url: null,
+      photoUrl: null,
       soat_exp: null,
       tec_exp: null,
       enabled: true,
@@ -395,6 +415,20 @@ describe('PATCH /vehicles/:id/enabled (toggle enabled)', () => {
     updated_at: new Date(),
   }
 
+  const completeVehicle = {
+    id: 'veh-1',
+    plate: 'ABC123',
+    brand: 'Toyota',
+    model: 'Corolla',
+    color: { name: 'White', hex: '#FFFFFF' },
+    photoUrl: null,
+    soat_exp: new Date('2026-01-01'),
+    tec_exp: new Date('2026-01-01'),
+    enabled: false,
+    created_at: new Date(),
+    updated_at: new Date(),
+  }
+
   it('returns 200 when enabled=false is sent and vehicle exists with no active assignment', async () => {
     mockFindById.mockResolvedValue(fakeVehicle)
     mockSetEnabled.mockResolvedValue(undefined)
@@ -408,8 +442,24 @@ describe('PATCH /vehicles/:id/enabled (toggle enabled)', () => {
     expect(mockSetEnabled).toHaveBeenCalledWith('veh-1', false)
   })
 
-  it('returns 200 when enabled=true is sent and vehicle exists', async () => {
-    mockFindById.mockResolvedValue({ ...fakeVehicle, enabled: true })
+  it('returns 422 with vehicle_incomplete and missing_fields when enabling an incomplete vehicle', async () => {
+    mockFindById.mockResolvedValue(fakeVehicle)
+
+    const { status, body } = await patch(server, '/vehicles/veh-1/enabled', { enabled: true })
+
+    expect(status).toBe(422)
+    expect(body.error).toBe('vehicle_incomplete')
+    expect(Array.isArray(body.missing_fields)).toBe(true)
+    expect(body.missing_fields).toContain('brand')
+    expect(body.missing_fields).toContain('model')
+    expect(body.missing_fields).toContain('color')
+    expect(body.missing_fields).toContain('soat_exp')
+    expect(body.missing_fields).toContain('tec_exp')
+    expect(mockSetEnabled).not.toHaveBeenCalled()
+  })
+
+  it('returns 200 when enabled=true is sent and vehicle is complete', async () => {
+    mockFindById.mockResolvedValue(completeVehicle)
     mockSetEnabled.mockResolvedValue(undefined)
 
     const { status, body } = await patch(server, '/vehicles/veh-1/enabled', { enabled: true })

--- a/src/Container/Container.ts
+++ b/src/Container/Container.ts
@@ -9,6 +9,7 @@ import DriverTokenRecordRepository from '../Repositories/DriverTokenRecordReposi
 import ServiceHistoryRepository from '../Repositories/ServiceHistoryRepository'
 import ServiceMetricsDailyRepository from '../Repositories/ServiceMetricsDailyRepository'
 import BillingRepository from '../Repositories/BillingRepository'
+import RechargeRepository from '../Repositories/RechargeRepository'
 
 class Container {
   private static sequelizeInstance: typeof sequelize
@@ -22,6 +23,7 @@ class Container {
   private static serviceHistoryRepository: ServiceHistoryRepository
   private static serviceMetricsDailyRepository: ServiceMetricsDailyRepository
   private static billingRepository: BillingRepository
+  private static rechargeRepository: RechargeRepository
 
   /**
    * Get or create Sequelize instance
@@ -110,6 +112,13 @@ class Container {
       this.billingRepository = new BillingRepository()
     }
     return this.billingRepository
+  }
+
+  static getRechargeRepository(): RechargeRepository {
+    if (!this.rechargeRepository) {
+      this.rechargeRepository = new RechargeRepository()
+    }
+    return this.rechargeRepository
   }
 
   /**

--- a/src/Database/Migrations/20260610000001-create-vehicles.ts
+++ b/src/Database/Migrations/20260610000001-create-vehicles.ts
@@ -1,0 +1,65 @@
+import { DataTypes, QueryInterface } from 'sequelize'
+
+export async function up(queryInterface: QueryInterface): Promise<void> {
+  await queryInterface.createTable('vehicles', {
+    id: {
+      type: DataTypes.UUID,
+      primaryKey: true,
+      allowNull: false,
+      defaultValue: DataTypes.UUIDV4,
+    },
+    plate: {
+      type: DataTypes.STRING(20),
+      allowNull: false,
+      unique: true,
+    },
+    brand: {
+      type: DataTypes.STRING(100),
+      allowNull: true,
+    },
+    model: {
+      type: DataTypes.STRING(100),
+      allowNull: true,
+    },
+    color: {
+      type: DataTypes.JSONB,
+      allowNull: true,
+    },
+    photo_url: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+    },
+    soat_exp: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
+    tec_exp: {
+      type: DataTypes.DATE,
+      allowNull: true,
+    },
+    enabled: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: true,
+    },
+    created_at: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updated_at: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+  })
+
+  await queryInterface.addIndex('vehicles', ['plate'], {
+    unique: true,
+    name: 'vehicles_plate_unique',
+  })
+}
+
+export async function down(queryInterface: QueryInterface): Promise<void> {
+  await queryInterface.dropTable('vehicles')
+}

--- a/src/Database/Migrations/20260610000002-create-driver-vehicles.ts
+++ b/src/Database/Migrations/20260610000002-create-driver-vehicles.ts
@@ -1,0 +1,52 @@
+import { DataTypes, QueryInterface } from 'sequelize'
+
+export async function up(queryInterface: QueryInterface): Promise<void> {
+  await queryInterface.createTable('driver_vehicles', {
+    id: {
+      type: DataTypes.UUID,
+      primaryKey: true,
+      allowNull: false,
+      defaultValue: DataTypes.UUIDV4,
+    },
+    driver_id: {
+      type: DataTypes.STRING(128),
+      allowNull: false,
+      references: {
+        model: 'drivers',
+        key: 'id',
+      },
+    },
+    vehicle_id: {
+      type: DataTypes.UUID,
+      allowNull: false,
+      references: {
+        model: 'vehicles',
+        key: 'id',
+      },
+    },
+    selectable: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: true,
+    },
+    added_at: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updated_at: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+  })
+
+  await queryInterface.addIndex('driver_vehicles', ['driver_id', 'vehicle_id'], {
+    unique: true,
+    name: 'driver_vehicles_driver_id_vehicle_id_unique',
+  })
+}
+
+export async function down(queryInterface: QueryInterface): Promise<void> {
+  await queryInterface.dropTable('driver_vehicles')
+}

--- a/src/Database/Migrations/20260610000003-create-active-vehicle-assignments.ts
+++ b/src/Database/Migrations/20260610000003-create-active-vehicle-assignments.ts
@@ -1,0 +1,20 @@
+import { QueryInterface } from 'sequelize'
+
+export async function up(queryInterface: QueryInterface): Promise<void> {
+  await queryInterface.sequelize.query(`
+    CREATE TABLE IF NOT EXISTS active_vehicle_assignments (
+      vehicle_id UUID NOT NULL,
+      driver_id VARCHAR(128) NOT NULL,
+      session_id VARCHAR(100),
+      acquired_at TIMESTAMP NOT NULL DEFAULT NOW(),
+      CONSTRAINT active_vehicle_assignments_pkey PRIMARY KEY (vehicle_id),
+      CONSTRAINT active_vehicle_assignments_driver_id_key UNIQUE (driver_id),
+      CONSTRAINT active_vehicle_assignments_vehicle_id_fkey FOREIGN KEY (vehicle_id) REFERENCES vehicles(id),
+      CONSTRAINT active_vehicle_assignments_driver_id_fkey FOREIGN KEY (driver_id) REFERENCES drivers(id)
+    )
+  `)
+}
+
+export async function down(queryInterface: QueryInterface): Promise<void> {
+  await queryInterface.sequelize.query(`DROP TABLE IF EXISTS active_vehicle_assignments`)
+}

--- a/src/Database/Migrations/20260610000004-add-drivers-selected-vehicle-id.ts
+++ b/src/Database/Migrations/20260610000004-add-drivers-selected-vehicle-id.ts
@@ -3,9 +3,22 @@ import { QueryInterface } from 'sequelize'
 export async function up(queryInterface: QueryInterface): Promise<void> {
   await queryInterface.sequelize.query(`
     ALTER TABLE drivers
-      ADD COLUMN selected_vehicle_id UUID NULL,
-      ADD CONSTRAINT drivers_selected_vehicle_id_fkey
-        FOREIGN KEY (selected_vehicle_id) REFERENCES vehicles(id) ON DELETE SET NULL
+      ADD COLUMN IF NOT EXISTS selected_vehicle_id UUID NULL
+  `)
+
+  await queryInterface.sequelize.query(`
+    DO $$
+    BEGIN
+      IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'drivers_selected_vehicle_id_fkey'
+      ) THEN
+        ALTER TABLE drivers
+          ADD CONSTRAINT drivers_selected_vehicle_id_fkey
+          FOREIGN KEY (selected_vehicle_id) REFERENCES vehicles(id) ON DELETE SET NULL;
+      END IF;
+    END $$;
   `)
 }
 

--- a/src/Database/Migrations/20260610000004-add-drivers-selected-vehicle-id.ts
+++ b/src/Database/Migrations/20260610000004-add-drivers-selected-vehicle-id.ts
@@ -1,0 +1,16 @@
+import { QueryInterface } from 'sequelize'
+
+export async function up(queryInterface: QueryInterface): Promise<void> {
+  await queryInterface.sequelize.query(`
+    ALTER TABLE drivers
+      ADD COLUMN selected_vehicle_id UUID NULL,
+      ADD CONSTRAINT drivers_selected_vehicle_id_fkey
+        FOREIGN KEY (selected_vehicle_id) REFERENCES vehicles(id) ON DELETE SET NULL
+  `)
+}
+
+export async function down(queryInterface: QueryInterface): Promise<void> {
+  await queryInterface.sequelize.query(`
+    ALTER TABLE drivers DROP COLUMN IF EXISTS selected_vehicle_id
+  `)
+}

--- a/src/Database/Migrations/20260610000005-add-services-vehicle-id.ts
+++ b/src/Database/Migrations/20260610000005-add-services-vehicle-id.ts
@@ -1,0 +1,24 @@
+import { QueryInterface } from 'sequelize'
+
+export async function up(queryInterface: QueryInterface): Promise<void> {
+  await queryInterface.sequelize.query(`
+    ALTER TABLE service_history
+      ADD COLUMN IF NOT EXISTS vehicle_id UUID NULL
+  `)
+  await queryInterface.sequelize.query(`
+    ALTER TABLE service_history
+      DROP CONSTRAINT IF EXISTS service_history_vehicle_id_fkey,
+      ADD CONSTRAINT service_history_vehicle_id_fkey
+        FOREIGN KEY (vehicle_id) REFERENCES vehicles(id) ON DELETE SET NULL
+  `)
+  await queryInterface.sequelize.query(`
+    CREATE INDEX IF NOT EXISTS service_history_vehicle_id_idx ON service_history(vehicle_id)
+  `)
+}
+
+export async function down(queryInterface: QueryInterface): Promise<void> {
+  await queryInterface.sequelize.query(`DROP INDEX IF EXISTS service_history_vehicle_id_idx`)
+  await queryInterface.sequelize.query(
+    `ALTER TABLE service_history DROP COLUMN IF EXISTS vehicle_id`
+  )
+}

--- a/src/Database/Migrations/20260610000010-migrate-vehicles-from-jsonb.ts
+++ b/src/Database/Migrations/20260610000010-migrate-vehicles-from-jsonb.ts
@@ -34,11 +34,17 @@ export async function up(queryInterface: QueryInterface): Promise<void> {
         vehicle->>'photo_url',
         NULL,
         NULL,
-        -- enabled=false if plate/brand/model missing
+        -- enabled=false if plate/brand/model missing, or soat_exp/tec_exp absent.
+        -- Rule tightened retroactively: soat_exp and tec_exp are always NULL at
+        -- migration time (drivers provided them separately), so all freshly-migrated
+        -- vehicles start disabled. Data fix for already-migrated DBs is handled by
+        -- 20260610000012-disable-incomplete-vehicles.ts.
         CASE WHEN
           (vehicle->>'plate' IS NULL OR vehicle->>'plate' = '') OR
           (vehicle->>'brand' IS NULL OR vehicle->>'brand' = '') OR
-          (vehicle->>'model' IS NULL OR vehicle->>'model' = '')
+          (vehicle->>'model' IS NULL OR vehicle->>'model' = '') OR
+          vehicle->>'soat_exp' IS NULL OR
+          vehicle->>'tec_exp' IS NULL
         THEN false ELSE true END,
         NOW(), NOW()
       FROM drivers
@@ -108,10 +114,9 @@ export async function up(queryInterface: QueryInterface): Promise<void> {
     )
 
     // Step 6: drop the legacy JSONB column now that all data is migrated
-    await queryInterface.sequelize.query(
-      `ALTER TABLE drivers DROP COLUMN IF EXISTS vehicle`,
-      { transaction: t }
-    )
+    await queryInterface.sequelize.query(`ALTER TABLE drivers DROP COLUMN IF EXISTS vehicle`, {
+      transaction: t,
+    })
   })
 }
 

--- a/src/Database/Migrations/20260610000010-migrate-vehicles-from-jsonb.ts
+++ b/src/Database/Migrations/20260610000010-migrate-vehicles-from-jsonb.ts
@@ -15,41 +15,81 @@ export async function up(queryInterface: QueryInterface): Promise<void> {
     // normalized plate = UPPER(REPLACE(REPLACE(vehicle->>'plate', ' ', ''), '-', ''))
     await queryInterface.sequelize.query(
       `
+      WITH vehicle_source AS (
+        SELECT
+          UPPER(REPLACE(REPLACE(vehicle->>'plate', ' ', ''), '-', '')) AS normalized_plate,
+          NULLIF(BTRIM(vehicle->>'brand'), '') AS brand,
+          NULLIF(BTRIM(vehicle->>'model'), '') AS model,
+          CASE
+            WHEN vehicle->>'color' IS NOT NULL AND vehicle->>'color' != 'null'
+            THEN (
+              CASE jsonb_typeof(vehicle->'color')
+                WHEN 'object' THEN vehicle->'color'
+                ELSE jsonb_build_object('name', vehicle->>'color')
+              END
+            )
+            ELSE NULL
+          END AS color,
+          NULLIF(BTRIM(COALESCE(vehicle->>'photoUrl', vehicle->>'photo_url')), '') AS photo_url,
+          CASE
+            WHEN NULLIF(BTRIM(vehicle->>'soat_exp'), '') IS NULL THEN NULL
+            WHEN BTRIM(vehicle->>'soat_exp') ~ '^\\d{13}$'
+              THEN to_timestamp((BTRIM(vehicle->>'soat_exp'))::double precision / 1000.0)
+            WHEN BTRIM(vehicle->>'soat_exp') ~ '^\\d{10}$'
+              THEN to_timestamp((BTRIM(vehicle->>'soat_exp'))::double precision)
+            WHEN BTRIM(vehicle->>'soat_exp') ~ '^\\d{4}-\\d{2}-\\d{2}'
+              AND to_char(to_date(LEFT(BTRIM(vehicle->>'soat_exp'), 10), 'YYYY-MM-DD'), 'YYYY-MM-DD') = LEFT(BTRIM(vehicle->>'soat_exp'), 10)
+              THEN to_date(LEFT(BTRIM(vehicle->>'soat_exp'), 10), 'YYYY-MM-DD')::timestamp
+            ELSE NULL
+          END AS soat_exp,
+          CASE
+            WHEN NULLIF(BTRIM(vehicle->>'tec_exp'), '') IS NULL THEN NULL
+            WHEN BTRIM(vehicle->>'tec_exp') ~ '^\\d{13}$'
+              THEN to_timestamp((BTRIM(vehicle->>'tec_exp'))::double precision / 1000.0)
+            WHEN BTRIM(vehicle->>'tec_exp') ~ '^\\d{10}$'
+              THEN to_timestamp((BTRIM(vehicle->>'tec_exp'))::double precision)
+            WHEN BTRIM(vehicle->>'tec_exp') ~ '^\\d{4}-\\d{2}-\\d{2}'
+              AND to_char(to_date(LEFT(BTRIM(vehicle->>'tec_exp'), 10), 'YYYY-MM-DD'), 'YYYY-MM-DD') = LEFT(BTRIM(vehicle->>'tec_exp'), 10)
+              THEN to_date(LEFT(BTRIM(vehicle->>'tec_exp'), 10), 'YYYY-MM-DD')::timestamp
+            ELSE NULL
+          END AS tec_exp
+        FROM drivers
+        WHERE vehicle IS NOT NULL
+          AND vehicle != '{}'::jsonb
+          AND vehicle->>'plate' IS NOT NULL
+          AND vehicle->>'plate' != ''
+      )
       INSERT INTO vehicles (id, plate, brand, model, color, photo_url, soat_exp, tec_exp, enabled, created_at, updated_at)
-      SELECT DISTINCT ON (UPPER(REPLACE(REPLACE(vehicle->>'plate', ' ', ''), '-', '')))
+      SELECT DISTINCT ON (normalized_plate)
         gen_random_uuid(),
-        UPPER(REPLACE(REPLACE(vehicle->>'plate', ' ', ''), '-', '')),
-        vehicle->>'brand',
-        vehicle->>'model',
+        normalized_plate,
+        brand,
+        model,
+        color,
+        photo_url,
+        soat_exp,
+        tec_exp,
         CASE
-          WHEN vehicle->>'color' IS NOT NULL AND vehicle->>'color' != 'null'
-          THEN (
-            CASE jsonb_typeof(vehicle->'color')
-              WHEN 'object' THEN vehicle->'color'
-              ELSE jsonb_build_object('name', vehicle->>'color')
-            END
-          )
-          ELSE NULL
+          WHEN brand IS NOT NULL
+            AND model IS NOT NULL
+            AND color IS NOT NULL
+            AND soat_exp IS NOT NULL
+            AND tec_exp IS NOT NULL
+          THEN true
+          ELSE false
         END,
-        vehicle->>'photo_url',
-        NULL,
-        NULL,
-        -- enabled=false if plate/brand/model missing, or soat_exp/tec_exp absent.
-        -- Rule tightened retroactively: soat_exp and tec_exp are always NULL at
-        -- migration time (drivers provided them separately), so all freshly-migrated
-        -- vehicles start disabled. Data fix for already-migrated DBs is handled by
-        -- 20260610000012-disable-incomplete-vehicles.ts.
-        CASE WHEN
-          (vehicle->>'plate' IS NULL OR vehicle->>'plate' = '') OR
-          (vehicle->>'brand' IS NULL OR vehicle->>'brand' = '') OR
-          (vehicle->>'model' IS NULL OR vehicle->>'model' = '') OR
-          vehicle->>'soat_exp' IS NULL OR
-          vehicle->>'tec_exp' IS NULL
-        THEN false ELSE true END,
-        NOW(), NOW()
-      FROM drivers
-      WHERE vehicle IS NOT NULL AND vehicle != '{}'::jsonb
-        AND vehicle->>'plate' IS NOT NULL AND vehicle->>'plate' != ''
+        NOW(),
+        NOW()
+      FROM vehicle_source
+      WHERE normalized_plate IS NOT NULL AND normalized_plate != ''
+      ORDER BY
+        normalized_plate,
+        (brand IS NOT NULL) DESC,
+        (model IS NOT NULL) DESC,
+        (color IS NOT NULL) DESC,
+        (photo_url IS NOT NULL) DESC,
+        (soat_exp IS NOT NULL) DESC,
+        (tec_exp IS NOT NULL) DESC
       ON CONFLICT (plate) DO NOTHING
     `,
       { transaction: t }

--- a/src/Database/Migrations/20260610000010-migrate-vehicles-from-jsonb.ts
+++ b/src/Database/Migrations/20260610000010-migrate-vehicles-from-jsonb.ts
@@ -113,10 +113,7 @@ export async function up(queryInterface: QueryInterface): Promise<void> {
       { transaction: t }
     )
 
-    // Step 6: drop the legacy JSONB column now that all data is migrated
-    await queryInterface.sequelize.query(`ALTER TABLE drivers DROP COLUMN IF EXISTS vehicle`, {
-      transaction: t,
-    })
+    // Step 6: keep the legacy JSONB column while the current model still reads it.
   })
 }
 

--- a/src/Database/Migrations/20260610000010-migrate-vehicles-from-jsonb.ts
+++ b/src/Database/Migrations/20260610000010-migrate-vehicles-from-jsonb.ts
@@ -1,0 +1,129 @@
+import { QueryInterface } from 'sequelize'
+
+export async function up(queryInterface: QueryInterface): Promise<void> {
+  await queryInterface.sequelize.transaction(async (t) => {
+    // Step 0: create backup table
+    await queryInterface.sequelize.query(
+      `
+      CREATE TABLE IF NOT EXISTS drivers_vehicle_backup AS
+      SELECT id AS driver_id, vehicle FROM drivers WHERE vehicle IS NOT NULL
+    `,
+      { transaction: t }
+    )
+
+    // Step 1: dedupe vehicles from JSONB into vehicles table
+    // normalized plate = UPPER(REPLACE(REPLACE(vehicle->>'plate', ' ', ''), '-', ''))
+    await queryInterface.sequelize.query(
+      `
+      INSERT INTO vehicles (id, plate, brand, model, color, photo_url, soat_exp, tec_exp, enabled, created_at, updated_at)
+      SELECT DISTINCT ON (UPPER(REPLACE(REPLACE(vehicle->>'plate', ' ', ''), '-', '')))
+        gen_random_uuid(),
+        UPPER(REPLACE(REPLACE(vehicle->>'plate', ' ', ''), '-', '')),
+        vehicle->>'brand',
+        vehicle->>'model',
+        CASE
+          WHEN vehicle->>'color' IS NOT NULL AND vehicle->>'color' != 'null'
+          THEN (
+            CASE jsonb_typeof(vehicle->'color')
+              WHEN 'object' THEN vehicle->'color'
+              ELSE jsonb_build_object('name', vehicle->>'color')
+            END
+          )
+          ELSE NULL
+        END,
+        vehicle->>'photo_url',
+        NULL,
+        NULL,
+        -- enabled=false if plate/brand/model missing
+        CASE WHEN
+          (vehicle->>'plate' IS NULL OR vehicle->>'plate' = '') OR
+          (vehicle->>'brand' IS NULL OR vehicle->>'brand' = '') OR
+          (vehicle->>'model' IS NULL OR vehicle->>'model' = '')
+        THEN false ELSE true END,
+        NOW(), NOW()
+      FROM drivers
+      WHERE vehicle IS NOT NULL AND vehicle != '{}'::jsonb
+        AND vehicle->>'plate' IS NOT NULL AND vehicle->>'plate' != ''
+      ON CONFLICT (plate) DO NOTHING
+    `,
+      { transaction: t }
+    )
+
+    // Step 2: insert driver_vehicles links
+    await queryInterface.sequelize.query(
+      `
+      INSERT INTO driver_vehicles (id, driver_id, vehicle_id, selectable, added_at, updated_at)
+      SELECT
+        gen_random_uuid(),
+        d.id,
+        v.id,
+        true,
+        NOW(),
+        NOW()
+      FROM drivers d
+      JOIN vehicles v ON v.plate = UPPER(REPLACE(REPLACE(d.vehicle->>'plate', ' ', ''), '-', ''))
+      WHERE d.vehicle IS NOT NULL
+        AND d.vehicle->>'plate' IS NOT NULL AND d.vehicle->>'plate' != ''
+      ON CONFLICT (driver_id, vehicle_id) DO NOTHING
+    `,
+      { transaction: t }
+    )
+
+    // Step 3: set selected_vehicle_id
+    await queryInterface.sequelize.query(
+      `
+      UPDATE drivers d
+      SET selected_vehicle_id = v.id
+      FROM vehicles v
+      WHERE v.plate = UPPER(REPLACE(REPLACE(d.vehicle->>'plate', ' ', ''), '-', ''))
+        AND d.vehicle->>'plate' IS NOT NULL AND d.vehicle->>'plate' != ''
+        AND d.selected_vehicle_id IS NULL
+    `,
+      { transaction: t }
+    )
+
+    // Step 4: inactivate drivers with no usable vehicle
+    await queryInterface.sequelize.query(
+      `
+      UPDATE drivers
+      SET enabled_at = 0
+      WHERE selected_vehicle_id IS NULL
+        AND enabled_at > 0
+        AND (vehicle IS NULL OR vehicle = '{}'::jsonb OR vehicle->>'plate' IS NULL OR vehicle->>'plate' = '')
+    `,
+      { transaction: t }
+    )
+
+    // Step 5: best-effort backfill service_history.vehicle_id
+    await queryInterface.sequelize.query(
+      `
+      UPDATE service_history sh
+      SET vehicle_id = v.id
+      FROM vehicles v
+      JOIN drivers d ON v.id = d.selected_vehicle_id
+      WHERE sh.driver_id = d.id
+        AND sh.vehicle_id IS NULL
+    `,
+      { transaction: t }
+    )
+
+    // Step 6: drop the legacy JSONB column now that all data is migrated
+    await queryInterface.sequelize.query(
+      `ALTER TABLE drivers DROP COLUMN IF EXISTS vehicle`,
+      { transaction: t }
+    )
+  })
+}
+
+export async function down(queryInterface: QueryInterface): Promise<void> {
+  await queryInterface.sequelize.query(
+    `ALTER TABLE drivers ADD COLUMN IF NOT EXISTS vehicle JSONB DEFAULT '{}'::jsonb NOT NULL`
+  )
+  await queryInterface.sequelize.query(
+    `UPDATE drivers d SET vehicle = b.vehicle FROM drivers_vehicle_backup b WHERE b.driver_id = d.id`
+  )
+  await queryInterface.sequelize.query(`UPDATE drivers SET selected_vehicle_id = NULL`)
+  await queryInterface.sequelize.query(`DELETE FROM driver_vehicles`)
+  await queryInterface.sequelize.query(`DELETE FROM vehicles`)
+  await queryInterface.sequelize.query(`DROP TABLE IF EXISTS drivers_vehicle_backup`)
+}

--- a/src/Database/Migrations/20260610000012-disable-incomplete-vehicles.ts
+++ b/src/Database/Migrations/20260610000012-disable-incomplete-vehicles.ts
@@ -1,0 +1,73 @@
+// Business rule: a vehicle must be DISABLED unless its data is complete.
+// "Complete" = brand non-empty, model non-empty, color not null,
+// soat_exp not null, tec_exp not null (presence only — no expiry check).
+//
+// This migration disables every currently-enabled vehicle that fails the
+// completeness check. It records the affected IDs in a backup table so
+// the down migration can re-enable exactly those rows.
+//
+// NOTE: Run this pre-flight count before applying in production to assess
+// scope before committing:
+//
+//   SELECT count(*) FROM vehicles
+//   WHERE enabled = true
+//     AND (
+//       brand IS NULL OR brand = '' OR
+//       model IS NULL OR model = '' OR
+//       color IS NULL OR
+//       soat_exp IS NULL OR
+//       tec_exp IS NULL
+//     );
+
+import { QueryInterface } from 'sequelize'
+
+export async function up(queryInterface: QueryInterface): Promise<void> {
+  await queryInterface.sequelize.transaction(async (t) => {
+    // Step 1: record which vehicles will be disabled so down() can reverse exactly these rows.
+    await queryInterface.sequelize.query(
+      `
+      CREATE TABLE IF NOT EXISTS vehicles_disabled_incomplete_backup AS
+      SELECT id FROM vehicles
+      WHERE enabled = true
+        AND (
+          brand IS NULL OR brand = '' OR
+          model IS NULL OR model = '' OR
+          color IS NULL OR
+          soat_exp IS NULL OR
+          tec_exp IS NULL
+        )
+    `,
+      { transaction: t }
+    )
+
+    // Step 2: disable every enabled vehicle that is missing required fields.
+    // Idempotent: re-running finds no enabled=true rows matching the predicate.
+    await queryInterface.sequelize.query(
+      `
+      UPDATE vehicles
+      SET enabled = false, updated_at = NOW()
+      WHERE enabled = true
+        AND (
+          brand IS NULL OR brand = '' OR
+          model IS NULL OR model = '' OR
+          color IS NULL OR
+          soat_exp IS NULL OR
+          tec_exp IS NULL
+        )
+    `,
+      { transaction: t }
+    )
+  })
+}
+
+export async function down(queryInterface: QueryInterface): Promise<void> {
+  // Re-enable only the rows that this migration disabled, then remove the backup table.
+  await queryInterface.sequelize.query(`
+    UPDATE vehicles
+    SET enabled = true, updated_at = NOW()
+    WHERE id IN (
+      SELECT id FROM vehicles_disabled_incomplete_backup
+    )
+  `)
+  await queryInterface.sequelize.query(`DROP TABLE IF EXISTS vehicles_disabled_incomplete_backup`)
+}

--- a/src/Database/Migrations/20260615000001-create-recharges.ts
+++ b/src/Database/Migrations/20260615000001-create-recharges.ts
@@ -1,0 +1,61 @@
+import { DataTypes, QueryInterface } from 'sequelize'
+
+export async function up(queryInterface: QueryInterface): Promise<void> {
+  await queryInterface.createTable('recharges', {
+    id: {
+      type: DataTypes.UUID,
+      primaryKey: true,
+      allowNull: false,
+      defaultValue: DataTypes.UUIDV4,
+    },
+    driver_id: {
+      type: DataTypes.STRING(128),
+      allowNull: false,
+      references: {
+        model: 'drivers',
+        key: 'id',
+      },
+    },
+    amount: {
+      type: DataTypes.FLOAT,
+      allowNull: false,
+    },
+    balance_before: {
+      type: DataTypes.FLOAT,
+      allowNull: false,
+    },
+    balance_after: {
+      type: DataTypes.FLOAT,
+      allowNull: false,
+    },
+    created_by_uid: {
+      type: DataTypes.STRING(255),
+      allowNull: false,
+    },
+    created_by_name: {
+      type: DataTypes.STRING(255),
+      allowNull: false,
+    },
+    note: {
+      type: DataTypes.STRING(1024),
+      allowNull: true,
+    },
+    created_at: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+      defaultValue: 0,
+    },
+  })
+
+  await queryInterface.addIndex('recharges', ['driver_id'], {
+    name: 'recharges_driver_id_idx',
+  })
+
+  await queryInterface.addIndex('recharges', ['created_at'], {
+    name: 'recharges_created_at_idx',
+  })
+}
+
+export async function down(queryInterface: QueryInterface): Promise<void> {
+  await queryInterface.dropTable('recharges')
+}

--- a/src/Helpers/PlateHelper.ts
+++ b/src/Helpers/PlateHelper.ts
@@ -1,0 +1,3 @@
+export function normalizePlate(s: string): string {
+  return s.toUpperCase().replace(/[\s-]/g, '')
+}

--- a/src/Helpers/__tests__/PlateHelper.spec.ts
+++ b/src/Helpers/__tests__/PlateHelper.spec.ts
@@ -1,0 +1,41 @@
+import { normalizePlate } from '../PlateHelper'
+
+describe('normalizePlate', () => {
+  describe('lowercases and removes spaces', () => {
+    it('"abc 123" → "ABC123"', () => {
+      expect(normalizePlate('abc 123')).toBe('ABC123')
+    })
+
+    it('"ABC 123" → "ABC123"', () => {
+      expect(normalizePlate('ABC 123')).toBe('ABC123')
+    })
+  })
+
+  describe('removes dashes', () => {
+    it('"abc-123" → "ABC123"', () => {
+      expect(normalizePlate('abc-123')).toBe('ABC123')
+    })
+  })
+
+  describe('removes spaces and dashes combined', () => {
+    it('"abc - 123" → "ABC123"', () => {
+      expect(normalizePlate('abc - 123')).toBe('ABC123')
+    })
+  })
+
+  describe('already normalized inputs', () => {
+    it('"ABC123" → "ABC123"', () => {
+      expect(normalizePlate('ABC123')).toBe('ABC123')
+    })
+
+    it('"XYZ999" → "XYZ999"', () => {
+      expect(normalizePlate('XYZ999')).toBe('XYZ999')
+    })
+  })
+
+  describe('edge cases', () => {
+    it('empty string → ""', () => {
+      expect(normalizePlate('')).toBe('')
+    })
+  })
+})

--- a/src/Interfaces/DriverInterface.ts
+++ b/src/Interfaces/DriverInterface.ts
@@ -18,5 +18,6 @@ export interface DriverInterface {
   enabled_at: number
   created_at: number
   last_connection?: number
+  selected_vehicle_id?: string | null
   availability?: DriverAvailabilityInterface
 }

--- a/src/Interfaces/RechargeInterface.ts
+++ b/src/Interfaces/RechargeInterface.ts
@@ -1,0 +1,11 @@
+export interface RechargeInterface {
+  id: string
+  driverId: string
+  amount: number
+  balanceBefore: number
+  balanceAfter: number
+  createdByUid: string
+  createdByName: string
+  note: string | null
+  created_at: number
+}

--- a/src/Interfaces/ServiceInterface.ts
+++ b/src/Interfaces/ServiceInterface.ts
@@ -20,6 +20,9 @@ export interface ServiceInterface {
   assigned_by?: string | null
   canceled_by?: string | null
   terminated_by?: string | null
-  // RTDB-only snapshot; not persisted to service_history
+  // RTDB-only snapshot fields (not persisted directly to service_history columns)
   client_completed_services_count?: number | null
+  vehicle?: { plate: string; brand?: string | null; model?: string | null; color?: any } | null
+  // Persisted FK — set from vehicle snapshot on finalize
+  vehicle_id?: string | null
 }

--- a/src/Interfaces/VehicleRecordInterface.ts
+++ b/src/Interfaces/VehicleRecordInterface.ts
@@ -1,0 +1,13 @@
+export interface VehicleRecordInterface {
+  id: string
+  plate: string
+  brand: string | null
+  model: string | null
+  color: { name: string; hex?: string } | null
+  photo_url: string | null
+  soat_exp: Date | null
+  tec_exp: Date | null
+  enabled: boolean
+  created_at: Date
+  updated_at: Date
+}

--- a/src/Interfaces/VehicleRecordInterface.ts
+++ b/src/Interfaces/VehicleRecordInterface.ts
@@ -4,10 +4,11 @@ export interface VehicleRecordInterface {
   brand: string | null
   model: string | null
   color: { name: string; hex?: string } | null
-  photo_url: string | null
+  photoUrl: string | null
   soat_exp: Date | null
   tec_exp: Date | null
   enabled: boolean
   created_at: Date
   updated_at: Date
+  linked_drivers_count?: number
 }

--- a/src/Models/ActiveVehicleAssignmentRecord.ts
+++ b/src/Models/ActiveVehicleAssignmentRecord.ts
@@ -1,0 +1,41 @@
+import { DataTypes, Model } from 'sequelize'
+import sequelize from '../Database/sequelize'
+
+class ActiveVehicleAssignmentRecord extends Model {
+  public vehicle_id!: string
+  public driver_id!: string
+  public session_id!: string | null
+  public readonly acquired_at!: Date
+}
+
+ActiveVehicleAssignmentRecord.init(
+  {
+    vehicle_id: {
+      type: DataTypes.UUID,
+      primaryKey: true,
+      allowNull: false,
+    },
+    driver_id: {
+      type: DataTypes.STRING(128),
+      allowNull: false,
+    },
+    session_id: {
+      type: DataTypes.STRING(100),
+      allowNull: true,
+      defaultValue: null,
+    },
+    acquired_at: {
+      type: DataTypes.DATE,
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+      field: 'acquired_at',
+    },
+  },
+  {
+    sequelize,
+    tableName: 'active_vehicle_assignments',
+    timestamps: false,
+  }
+)
+
+export default ActiveVehicleAssignmentRecord

--- a/src/Models/DriverRecord.ts
+++ b/src/Models/DriverRecord.ts
@@ -133,4 +133,20 @@ DriverRecord.init(
   }
 )
 
+export function setupDriverAssociations(): void {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { default: VehicleRecord } = require('./VehicleRecord')
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { default: DriverVehicleRecord } = require('./DriverVehicleRecord')
+
+  DriverRecord.belongsTo(VehicleRecord, {
+    foreignKey: 'selected_vehicle_id',
+    as: 'selectedVehicle',
+  })
+  DriverRecord.hasMany(DriverVehicleRecord, {
+    foreignKey: 'driver_id',
+    as: 'driverVehicles',
+  })
+}
+
 export default DriverRecord

--- a/src/Models/DriverRecord.ts
+++ b/src/Models/DriverRecord.ts
@@ -35,6 +35,7 @@ class DriverRecord
   public enabled_at!: number
   public created_at!: number
   public last_connection!: number
+  public selected_vehicle_id!: string | null
   public readonly updated_at!: Date
 }
 
@@ -118,6 +119,11 @@ DriverRecord.init(
       type: DataTypes.BIGINT,
       allowNull: false,
       defaultValue: 0,
+    },
+    selected_vehicle_id: {
+      type: DataTypes.UUID,
+      allowNull: true,
+      defaultValue: null,
     },
     updated_at: {
       type: DataTypes.DATE,

--- a/src/Models/DriverVehicleRecord.ts
+++ b/src/Models/DriverVehicleRecord.ts
@@ -1,0 +1,53 @@
+import { DataTypes, Model } from 'sequelize'
+import sequelize from '../Database/sequelize'
+
+class DriverVehicleRecord extends Model {
+  public id!: string
+  public driver_id!: string
+  public vehicle_id!: string
+  public selectable!: boolean
+  public readonly added_at!: Date
+  public readonly updated_at!: Date
+}
+
+DriverVehicleRecord.init(
+  {
+    id: {
+      type: DataTypes.UUID,
+      primaryKey: true,
+      allowNull: false,
+      defaultValue: DataTypes.UUIDV4,
+    },
+    driver_id: {
+      type: DataTypes.STRING(128),
+      allowNull: false,
+    },
+    vehicle_id: {
+      type: DataTypes.UUID,
+      allowNull: false,
+    },
+    selectable: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: true,
+    },
+    added_at: {
+      type: DataTypes.DATE,
+      defaultValue: DataTypes.NOW,
+      field: 'added_at',
+    },
+    updated_at: {
+      type: DataTypes.DATE,
+      defaultValue: DataTypes.NOW,
+    },
+  },
+  {
+    sequelize,
+    tableName: 'driver_vehicles',
+    timestamps: true,
+    createdAt: 'added_at',
+    updatedAt: 'updated_at',
+  }
+)
+
+export default DriverVehicleRecord

--- a/src/Models/RechargeRecord.ts
+++ b/src/Models/RechargeRecord.ts
@@ -1,0 +1,85 @@
+import { DataTypes, Model, Optional } from 'sequelize'
+import sequelize from '../Database/sequelize'
+import { RechargeInterface } from '../Interfaces/RechargeInterface'
+
+type RechargeCreationAttributes = Optional<RechargeInterface, 'note' | 'created_at'>
+
+class RechargeRecord
+  extends Model<RechargeInterface, RechargeCreationAttributes>
+  implements RechargeInterface
+{
+  public id!: string
+  public driverId!: string
+  public amount!: number
+  public balanceBefore!: number
+  public balanceAfter!: number
+  public createdByUid!: string
+  public createdByName!: string
+  public note!: string | null
+  public created_at!: number
+}
+
+RechargeRecord.init(
+  {
+    id: {
+      type: DataTypes.UUID,
+      primaryKey: true,
+      allowNull: false,
+      defaultValue: DataTypes.UUIDV4,
+    },
+    driverId: {
+      type: DataTypes.STRING(128),
+      allowNull: false,
+      field: 'driver_id',
+    },
+    amount: {
+      type: DataTypes.FLOAT,
+      allowNull: false,
+    },
+    balanceBefore: {
+      type: DataTypes.FLOAT,
+      allowNull: false,
+      field: 'balance_before',
+    },
+    balanceAfter: {
+      type: DataTypes.FLOAT,
+      allowNull: false,
+      field: 'balance_after',
+    },
+    createdByUid: {
+      type: DataTypes.STRING(255),
+      allowNull: false,
+      field: 'created_by_uid',
+    },
+    createdByName: {
+      type: DataTypes.STRING(255),
+      allowNull: false,
+      field: 'created_by_name',
+    },
+    note: {
+      type: DataTypes.STRING(1024),
+      allowNull: true,
+      defaultValue: null,
+    },
+    created_at: {
+      type: DataTypes.BIGINT,
+      allowNull: false,
+      defaultValue: 0,
+    },
+  } as any,
+  {
+    sequelize,
+    tableName: 'recharges',
+    timestamps: false,
+  }
+)
+
+export function setupRechargeAssociations(): void {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { default: DriverRecord } = require('./DriverRecord')
+
+  RechargeRecord.belongsTo(DriverRecord, { foreignKey: 'driver_id', as: 'driver' })
+  DriverRecord.hasMany(RechargeRecord, { foreignKey: 'driver_id', as: 'recharges' })
+}
+
+export default RechargeRecord

--- a/src/Models/ServiceHistoryRecord.ts
+++ b/src/Models/ServiceHistoryRecord.ts
@@ -36,6 +36,7 @@ class ServiceHistoryRecord
   public assigned_by!: string | null
   public canceled_by!: string | null
   public terminated_by!: string | null
+  public vehicle_id!: string | null
   public readonly updated_at!: Date
 }
 
@@ -118,6 +119,11 @@ ServiceHistoryRecord.init(
     },
     terminated_by: {
       type: DataTypes.STRING(128),
+      allowNull: true,
+      defaultValue: null,
+    },
+    vehicle_id: {
+      type: DataTypes.UUID,
       allowNull: true,
       defaultValue: null,
     },

--- a/src/Models/VehicleRecord.ts
+++ b/src/Models/VehicleRecord.ts
@@ -7,7 +7,7 @@ type VehicleCreationAttributes = Optional<
   | 'brand'
   | 'model'
   | 'color'
-  | 'photo_url'
+  | 'photoUrl'
   | 'soat_exp'
   | 'tec_exp'
   | 'enabled'
@@ -24,7 +24,7 @@ class VehicleRecord
   public brand!: string | null
   public model!: string | null
   public color!: { name: string; hex?: string } | null
-  public photo_url!: string | null
+  public photoUrl!: string | null
   public soat_exp!: Date | null
   public tec_exp!: Date | null
   public enabled!: boolean
@@ -60,7 +60,7 @@ VehicleRecord.init(
       allowNull: true,
       defaultValue: null,
     },
-    photo_url: {
+    photoUrl: {
       type: DataTypes.TEXT,
       allowNull: true,
       defaultValue: null,

--- a/src/Models/VehicleRecord.ts
+++ b/src/Models/VehicleRecord.ts
@@ -1,0 +1,104 @@
+import { DataTypes, Model, Optional } from 'sequelize'
+import sequelize from '../Database/sequelize'
+import { VehicleRecordInterface } from '../Interfaces/VehicleRecordInterface'
+
+type VehicleCreationAttributes = Optional<
+  VehicleRecordInterface,
+  | 'brand'
+  | 'model'
+  | 'color'
+  | 'photo_url'
+  | 'soat_exp'
+  | 'tec_exp'
+  | 'enabled'
+  | 'created_at'
+  | 'updated_at'
+>
+
+class VehicleRecord
+  extends Model<VehicleRecordInterface, VehicleCreationAttributes>
+  implements VehicleRecordInterface
+{
+  public id!: string
+  public plate!: string
+  public brand!: string | null
+  public model!: string | null
+  public color!: { name: string; hex?: string } | null
+  public photo_url!: string | null
+  public soat_exp!: Date | null
+  public tec_exp!: Date | null
+  public enabled!: boolean
+  public readonly created_at!: Date
+  public readonly updated_at!: Date
+}
+
+VehicleRecord.init(
+  {
+    id: {
+      type: DataTypes.UUID,
+      primaryKey: true,
+      allowNull: false,
+      defaultValue: DataTypes.UUIDV4,
+    },
+    plate: {
+      type: DataTypes.STRING(20),
+      allowNull: false,
+      unique: true,
+    },
+    brand: {
+      type: DataTypes.STRING(100),
+      allowNull: true,
+      defaultValue: null,
+    },
+    model: {
+      type: DataTypes.STRING(100),
+      allowNull: true,
+      defaultValue: null,
+    },
+    color: {
+      type: DataTypes.JSONB,
+      allowNull: true,
+      defaultValue: null,
+    },
+    photo_url: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+      defaultValue: null,
+      field: 'photo_url',
+    },
+    soat_exp: {
+      type: DataTypes.DATE,
+      allowNull: true,
+      defaultValue: null,
+      field: 'soat_exp',
+    },
+    tec_exp: {
+      type: DataTypes.DATE,
+      allowNull: true,
+      defaultValue: null,
+      field: 'tec_exp',
+    },
+    enabled: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: true,
+    },
+    created_at: {
+      type: DataTypes.DATE,
+      defaultValue: DataTypes.NOW,
+    },
+    updated_at: {
+      type: DataTypes.DATE,
+      defaultValue: DataTypes.NOW,
+    },
+  } as any,
+  {
+    sequelize,
+    tableName: 'vehicles',
+    timestamps: true,
+    createdAt: 'created_at',
+    updatedAt: 'updated_at',
+  }
+)
+
+export default VehicleRecord

--- a/src/Repositories/ActiveVehicleAssignmentRepository.ts
+++ b/src/Repositories/ActiveVehicleAssignmentRepository.ts
@@ -1,0 +1,50 @@
+import ActiveVehicleAssignmentRecord from '../Models/ActiveVehicleAssignmentRecord'
+
+export interface ActiveVehicleAssignment {
+  vehicle_id: string
+  driver_id: string
+  session_id: string | null
+  acquired_at: Date
+}
+
+class ActiveVehicleAssignmentRepository {
+  async acquire(driverId: string, vehicleId: string, sessionId: string | null): Promise<void> {
+    await ActiveVehicleAssignmentRecord.create({
+      vehicle_id: vehicleId,
+      driver_id: driverId,
+      session_id: sessionId,
+    })
+  }
+
+  async releaseByDriver(driverId: string): Promise<void> {
+    await ActiveVehicleAssignmentRecord.destroy({ where: { driver_id: driverId } })
+  }
+
+  async releaseByVehicle(vehicleId: string): Promise<void> {
+    await ActiveVehicleAssignmentRecord.destroy({ where: { vehicle_id: vehicleId } })
+  }
+
+  async findByDriver(driverId: string): Promise<ActiveVehicleAssignment | null> {
+    const record = await ActiveVehicleAssignmentRecord.findOne({ where: { driver_id: driverId } })
+    if (!record) return null
+    return this.mapRecord(record)
+  }
+
+  async findByVehicle(vehicleId: string): Promise<ActiveVehicleAssignment | null> {
+    const record = await ActiveVehicleAssignmentRecord.findByPk(vehicleId)
+    if (!record) return null
+    return this.mapRecord(record)
+  }
+
+  private mapRecord(record: ActiveVehicleAssignmentRecord): ActiveVehicleAssignment {
+    const plain = record.get({ plain: true }) as any
+    return {
+      vehicle_id: plain.vehicle_id,
+      driver_id: plain.driver_id,
+      session_id: plain.session_id ?? null,
+      acquired_at: plain.acquired_at,
+    }
+  }
+}
+
+export default new ActiveVehicleAssignmentRepository()

--- a/src/Repositories/DriverRecordRepository.ts
+++ b/src/Repositories/DriverRecordRepository.ts
@@ -1,6 +1,8 @@
-import { Op, literal, WhereOptions } from 'sequelize'
+import { Op, QueryTypes, literal, WhereOptions } from 'sequelize'
+import sequelize from '../Database/sequelize'
 import DriverRecord from '../Models/DriverRecord'
 import { DriverInterface } from '../Interfaces/DriverInterface'
+import { VehicleRecordInterface } from '../Interfaces/VehicleRecordInterface'
 import Driver from '../Models/Driver'
 import { buildDriverAvailability } from '../Services/drivers/DriverAvailability'
 
@@ -9,6 +11,7 @@ export interface DriverListQuery {
   status?: string
   paymentMode?: string
   inactiveDays?: number
+  needsVehicle?: boolean
   sort?: string
   page?: number
   perPage?: number
@@ -48,9 +51,17 @@ class DriverRecordRepository {
           { email: { [Op.iLike]: searchPattern } },
           { phone: { [Op.iLike]: searchPattern } },
           { document: { [Op.iLike]: searchPattern } },
-          literal(`vehicle->>'plate' ILIKE :search`),
+          literal(`"DriverRecord"."id" IN (
+            SELECT dv.driver_id FROM driver_vehicles dv
+            JOIN vehicles v ON v.id = dv.vehicle_id
+            WHERE v.plate ILIKE :search
+          )`),
         ],
       })
+    }
+
+    if (query.needsVehicle) {
+      andWhere.push(literal(`"DriverRecord"."selected_vehicle_id" IS NULL`))
     }
 
     if (query.status === 'enabled') {
@@ -83,8 +94,59 @@ class DriverRecordRepository {
       replacements,
     })
 
+    const driverPlains = rows.map((driver) => {
+      const plain = driver.get({ plain: true }) as any
+      return plain
+    })
+
+    // Bulk-fetch selected vehicles to avoid N+1
+    const selectedVehicleIds = driverPlains
+      .map((d: any) => d.selected_vehicle_id)
+      .filter((id: any): id is string => !!id)
+
+    const vehicleMap = new Map<string, VehicleRecordInterface>()
+    if (selectedVehicleIds.length > 0) {
+      const placeholders = selectedVehicleIds.map((_: any, i: number) => `:sv${i}`).join(', ')
+      const vehicleReplacements: Record<string, string> = {}
+      selectedVehicleIds.forEach((id: string, i: number) => {
+        vehicleReplacements[`sv${i}`] = id
+      })
+      const vehicleRows = await sequelize.query<VehicleRecordInterface>(
+        `SELECT * FROM vehicles WHERE id IN (${placeholders})`,
+        { replacements: vehicleReplacements, type: QueryTypes.SELECT }
+      )
+      vehicleRows.forEach((v) => vehicleMap.set(v.id, v))
+    }
+
+    // Bulk-fetch active vehicle assignments to avoid N+1
+    const driverIds = driverPlains.map((d: any) => d.id as string)
+    const activeVehicleMap = new Map<string, string>()
+    if (driverIds.length > 0) {
+      const placeholders = driverIds.map((_: any, i: number) => `:did${i}`).join(', ')
+      const activeReplacements: Record<string, string> = {}
+      driverIds.forEach((id: string, i: number) => {
+        activeReplacements[`did${i}`] = id
+      })
+      const activeRows = await sequelize.query<{ driver_id: string; vehicle_id: string }>(
+        `SELECT driver_id, vehicle_id FROM active_vehicle_assignments WHERE driver_id IN (${placeholders})`,
+        { replacements: activeReplacements, type: QueryTypes.SELECT }
+      )
+      activeRows.forEach((r) => activeVehicleMap.set(r.driver_id, r.vehicle_id))
+    }
+
     return {
-      rows: rows.map((driver) => this.mapDriver(driver)),
+      rows: rows.map((driver) => {
+        const mapped = this.mapDriver(driver)
+        const plain = driver.get({ plain: true }) as any
+        const selected_vehicle_id = plain.selected_vehicle_id ?? null
+        return {
+          ...mapped,
+          selected_vehicle: selected_vehicle_id
+            ? (vehicleMap.get(selected_vehicle_id) ?? null)
+            : null,
+          active_vehicle_id: activeVehicleMap.get(mapped.id!) ?? null,
+        }
+      }),
       total: count,
     }
   }

--- a/src/Repositories/DriverRecordRepository.ts
+++ b/src/Repositories/DriverRecordRepository.ts
@@ -293,6 +293,7 @@ class DriverRecordRepository {
       enabled_at: Number(plain.enabled_at ?? 0),
       created_at: Number(plain.created_at ?? 0),
       last_connection: Number(plain.last_connection ?? 0),
+      selected_vehicle_id: plain.selected_vehicle_id ?? null,
       availability: buildDriverAvailability({
         paymentMode: plain.paymentMode ?? 'monthly',
         balance: Number(plain.balance ?? 0),

--- a/src/Repositories/DriverVehicleRepository.ts
+++ b/src/Repositories/DriverVehicleRepository.ts
@@ -178,7 +178,7 @@ class DriverVehicleRepository {
         brand: row.brand ?? null,
         model: row.model ?? null,
         color: row.color ?? null,
-        photo_url: row.photo_url ?? null,
+        photoUrl: row.photo_url ?? null,
         soat_exp: row.soat_exp ?? null,
         tec_exp: row.tec_exp ?? null,
         enabled: Boolean(row.enabled),

--- a/src/Repositories/DriverVehicleRepository.ts
+++ b/src/Repositories/DriverVehicleRepository.ts
@@ -1,0 +1,192 @@
+import { QueryTypes, Transaction } from 'sequelize'
+import sequelize from '../Database/sequelize'
+import DriverVehicleRecord from '../Models/DriverVehicleRecord'
+import { VehicleRecordInterface } from '../Interfaces/VehicleRecordInterface'
+
+export interface DriverVehicleLink {
+  id: string
+  driver_id: string
+  vehicle_id: string
+  selectable: boolean
+  added_at: Date
+  updated_at: Date
+  vehicle: VehicleRecordInterface
+}
+
+class DriverVehicleRepository {
+  async listForDriver(
+    driverId: string,
+    opts: { includeAll?: boolean } = {}
+  ): Promise<DriverVehicleLink[]> {
+    const gateClause = opts.includeAll ? '' : 'AND dv.selectable = true AND v.enabled = true'
+
+    const rows = await sequelize.query<{
+      id: string
+      driver_id: string
+      vehicle_id: string
+      selectable: boolean
+      added_at: Date
+      updated_at: Date
+      v_id: string
+      plate: string
+      brand: string | null
+      model: string | null
+      color: { name: string; hex?: string } | null
+      photo_url: string | null
+      soat_exp: Date | null
+      tec_exp: Date | null
+      enabled: boolean
+      created_at: Date
+      v_updated_at: Date
+    }>(
+      `SELECT
+        dv.id,
+        dv.driver_id,
+        dv.vehicle_id,
+        dv.selectable,
+        dv.added_at,
+        dv.updated_at,
+        v.id          AS v_id,
+        v.plate,
+        v.brand,
+        v.model,
+        v.color,
+        v.photo_url,
+        v.soat_exp,
+        v.tec_exp,
+        v.enabled,
+        v.created_at,
+        v.updated_at  AS v_updated_at
+      FROM driver_vehicles dv
+      JOIN vehicles v ON v.id = dv.vehicle_id
+      WHERE dv.driver_id = :driverId
+      ${gateClause}
+      ORDER BY dv.added_at DESC`,
+      {
+        replacements: { driverId },
+        type: QueryTypes.SELECT,
+      }
+    )
+
+    return rows.map((row) => this.mapRow(row))
+  }
+
+  async link(driverId: string, vehicleId: string, txn?: Transaction): Promise<DriverVehicleRecord> {
+    return DriverVehicleRecord.create(
+      {
+        driver_id: driverId,
+        vehicle_id: vehicleId,
+        selectable: true,
+      } as any,
+      { transaction: txn }
+    )
+  }
+
+  async setSelectable(driverId: string, vehicleId: string, selectable: boolean): Promise<void> {
+    await DriverVehicleRecord.update({ selectable } as any, {
+      where: { driver_id: driverId, vehicle_id: vehicleId },
+    })
+  }
+
+  async findEligibleForDriver(driverId: string): Promise<DriverVehicleLink[]> {
+    return this.listForDriver(driverId, { includeAll: false })
+  }
+
+  async findMostRecentEligible(driverId: string): Promise<DriverVehicleLink | null> {
+    const rows = await sequelize.query<{
+      id: string
+      driver_id: string
+      vehicle_id: string
+      selectable: boolean
+      added_at: Date
+      updated_at: Date
+      v_id: string
+      plate: string
+      brand: string | null
+      model: string | null
+      color: { name: string; hex?: string } | null
+      photo_url: string | null
+      soat_exp: Date | null
+      tec_exp: Date | null
+      enabled: boolean
+      created_at: Date
+      v_updated_at: Date
+    }>(
+      `SELECT
+        dv.id,
+        dv.driver_id,
+        dv.vehicle_id,
+        dv.selectable,
+        dv.added_at,
+        dv.updated_at,
+        v.id          AS v_id,
+        v.plate,
+        v.brand,
+        v.model,
+        v.color,
+        v.photo_url,
+        v.soat_exp,
+        v.tec_exp,
+        v.enabled,
+        v.created_at,
+        v.updated_at  AS v_updated_at
+      FROM driver_vehicles dv
+      JOIN vehicles v ON v.id = dv.vehicle_id
+      WHERE dv.driver_id = :driverId
+        AND dv.selectable = true
+        AND v.enabled = true
+      ORDER BY dv.added_at DESC
+      LIMIT 1`,
+      {
+        replacements: { driverId },
+        type: QueryTypes.SELECT,
+      }
+    )
+
+    return rows.length > 0 ? this.mapRow(rows[0]) : null
+  }
+
+  private mapRow(row: {
+    id: string
+    driver_id: string
+    vehicle_id: string
+    selectable: boolean
+    added_at: Date
+    updated_at: Date
+    v_id: string
+    plate: string
+    brand: string | null
+    model: string | null
+    color: { name: string; hex?: string } | null
+    photo_url: string | null
+    soat_exp: Date | null
+    tec_exp: Date | null
+    enabled: boolean
+    created_at: Date
+    v_updated_at: Date
+  }): DriverVehicleLink {
+    return {
+      id: row.id,
+      driver_id: row.driver_id,
+      vehicle_id: row.vehicle_id,
+      selectable: Boolean(row.selectable),
+      added_at: row.added_at,
+      updated_at: row.updated_at,
+      vehicle: {
+        id: row.v_id,
+        plate: row.plate,
+        brand: row.brand ?? null,
+        model: row.model ?? null,
+        color: row.color ?? null,
+        photo_url: row.photo_url ?? null,
+        soat_exp: row.soat_exp ?? null,
+        tec_exp: row.tec_exp ?? null,
+        enabled: Boolean(row.enabled),
+        created_at: row.created_at,
+        updated_at: row.v_updated_at,
+      },
+    }
+  }
+}
+
+export default DriverVehicleRepository

--- a/src/Repositories/RechargeRepository.ts
+++ b/src/Repositories/RechargeRepository.ts
@@ -1,0 +1,125 @@
+import sequelize from '../Database/sequelize'
+import RechargeRecord from '../Models/RechargeRecord'
+import DriverRecord from '../Models/DriverRecord'
+import { RechargeInterface } from '../Interfaces/RechargeInterface'
+import { DriverInterface } from '../Interfaces/DriverInterface'
+import { buildDriverAvailability } from '../Services/drivers/DriverAvailability'
+
+class RechargeRepository {
+  async create({
+    driverId,
+    amount,
+    createdBy,
+    note,
+  }: {
+    driverId: string
+    amount: number
+    createdBy: { uid: string; name: string }
+    note?: string | null
+  }): Promise<{ recharge: RechargeInterface; driver: DriverInterface }> {
+    const txn = await sequelize.transaction()
+    try {
+      const driver = await DriverRecord.findOne({
+        where: { id: driverId },
+        lock: true,
+        transaction: txn,
+      })
+
+      if (!driver) {
+        throw new Error('Driver not found')
+      }
+
+      const balanceBefore = Number(driver.balance ?? 0)
+      const balanceAfter = balanceBefore + amount
+
+      driver.balance = balanceAfter
+      if (driver.paymentMode === 'percentage' && balanceAfter <= 0) {
+        driver.enabled_at = 0
+      }
+      await driver.save({ transaction: txn })
+
+      const recharge = await RechargeRecord.create(
+        {
+          driverId,
+          amount,
+          balanceBefore,
+          balanceAfter,
+          createdByUid: createdBy.uid,
+          createdByName: createdBy.name,
+          note: note ?? null,
+          created_at: Math.floor(Date.now() / 1000),
+        } as any,
+        { transaction: txn }
+      )
+
+      await txn.commit()
+
+      return { recharge: this.mapRecharge(recharge), driver: this.mapDriver(driver) }
+    } catch (error) {
+      await txn.rollback()
+      throw error
+    }
+  }
+
+  async listForDriver(
+    driverId: string,
+    { page, perPage }: { page?: number; perPage?: number } = {}
+  ): Promise<{ rows: RechargeInterface[]; total: number }> {
+    const resolvedPerPage = perPage ?? 20
+    const resolvedPage = page ?? 1
+
+    const { count, rows } = await RechargeRecord.findAndCountAll({
+      where: { driverId },
+      order: [['created_at', 'DESC']],
+      limit: resolvedPerPage,
+      offset: (resolvedPage - 1) * resolvedPerPage,
+    })
+
+    return { rows: rows.map((r) => this.mapRecharge(r)), total: count }
+  }
+
+  private mapRecharge(r: RechargeRecord): RechargeInterface {
+    const plain = r.get({ plain: true }) as any
+    return {
+      id: plain.id,
+      driverId: plain.driverId,
+      amount: Number(plain.amount),
+      balanceBefore: Number(plain.balanceBefore),
+      balanceAfter: Number(plain.balanceAfter),
+      createdByUid: plain.createdByUid,
+      createdByName: plain.createdByName,
+      note: plain.note ?? null,
+      created_at: Number(plain.created_at),
+    }
+  }
+
+  private mapDriver(d: DriverRecord): DriverInterface {
+    const plain = d.get({ plain: true }) as any
+    return {
+      id: plain.id,
+      name: plain.name,
+      email: plain.email,
+      password: plain.password ?? null,
+      phone: plain.phone,
+      phone2: plain.phone2 ?? null,
+      docType: plain.docType,
+      paymentMode: plain.paymentMode ?? 'monthly',
+      document: plain.document,
+      photoUrl: plain.photoUrl ?? null,
+      vehicle: plain.vehicle ?? {},
+      device: plain.device ?? null,
+      balance: Number(plain.balance ?? 0),
+      enabled_at: Number(plain.enabled_at ?? 0),
+      created_at: Number(plain.created_at ?? 0),
+      last_connection: Number(plain.last_connection ?? 0),
+      selected_vehicle_id: plain.selected_vehicle_id ?? null,
+      availability: buildDriverAvailability({
+        paymentMode: plain.paymentMode ?? 'monthly',
+        balance: Number(plain.balance ?? 0),
+        enabled_at: Number(plain.enabled_at ?? 0),
+      }),
+    }
+  }
+}
+
+export default RechargeRepository

--- a/src/Repositories/VehicleRepository.ts
+++ b/src/Repositories/VehicleRepository.ts
@@ -1,8 +1,23 @@
-import { Op, QueryTypes, Transaction, WhereOptions } from 'sequelize'
+import { Op, QueryTypes, Transaction, WhereOptions, literal } from 'sequelize'
 import sequelize from '../Database/sequelize'
 import VehicleRecord from '../Models/VehicleRecord'
 import { VehicleRecordInterface } from '../Interfaces/VehicleRecordInterface'
 import { normalizePlate } from '../Helpers/PlateHelper'
+
+export function getMissingVehicleFields(v: Partial<VehicleRecordInterface>): string[] {
+  const missing: string[] = []
+  if (!v.brand || typeof v.brand !== 'string' || v.brand.trim() === '') missing.push('brand')
+  if (!v.model || typeof v.model !== 'string' || v.model.trim() === '') missing.push('model')
+  if (!v.color || typeof v.color.name !== 'string' || v.color.name.trim() === '')
+    missing.push('color')
+  if (v.soat_exp == null) missing.push('soat_exp')
+  if (v.tec_exp == null) missing.push('tec_exp')
+  return missing
+}
+
+export function isVehicleComplete(v: Partial<VehicleRecordInterface>): boolean {
+  return getMissingVehicleFields(v).length === 0
+}
 
 export interface VehicleSearchQuery {
   search?: string
@@ -45,7 +60,7 @@ class VehicleRepository {
     if (rows) {
       return rows as VehicleRecordInterface
     }
-    const isComplete = !!(fullPayload.brand?.trim() && fullPayload.model?.trim())
+    const isComplete = isVehicleComplete(fullPayload)
     const created = await VehicleRecord.create(
       { ...fullPayload, plate: normalizedPlate, enabled: isComplete } as any,
       { transaction: txn }
@@ -122,7 +137,7 @@ class VehicleRepository {
       brand: first.brand,
       model: first.model,
       color: first.color,
-      photo_url: first.photo_url,
+      photoUrl: first.photo_url,
       soat_exp: first.soat_exp,
       tec_exp: first.tec_exp,
       enabled: first.enabled,
@@ -174,11 +189,18 @@ class VehicleRepository {
 
     const where: WhereOptions<any> = andWhere.length > 0 ? { [Op.and]: andWhere } : {}
 
+    const linkedDriversCountSubquery = literal(
+      `(SELECT COUNT(dv.id) FROM driver_vehicles dv WHERE dv.vehicle_id = "VehicleRecord"."id")`
+    )
+
     const { count, rows } = await VehicleRecord.findAndCountAll({
       where,
       order,
       limit: perPage,
       offset: (page - 1) * perPage,
+      attributes: {
+        include: [[linkedDriversCountSubquery, 'linked_drivers_count']],
+      },
     })
 
     return {
@@ -189,19 +211,23 @@ class VehicleRepository {
 
   private mapVehicle(record: VehicleRecord): VehicleRecordInterface {
     const plain = record.get({ plain: true }) as any
-    return {
+    const mapped: VehicleRecordInterface = {
       id: plain.id,
       plate: plain.plate,
       brand: plain.brand ?? null,
       model: plain.model ?? null,
       color: plain.color ?? null,
-      photo_url: plain.photo_url ?? null,
+      photoUrl: plain.photoUrl ?? null,
       soat_exp: plain.soat_exp ?? null,
       tec_exp: plain.tec_exp ?? null,
       enabled: Boolean(plain.enabled),
       created_at: plain.created_at,
       updated_at: plain.updated_at,
     }
+    if (plain.linked_drivers_count !== undefined) {
+      mapped.linked_drivers_count = Number(plain.linked_drivers_count)
+    }
+    return mapped
   }
 }
 

--- a/src/Repositories/VehicleRepository.ts
+++ b/src/Repositories/VehicleRepository.ts
@@ -1,0 +1,208 @@
+import { Op, QueryTypes, Transaction, WhereOptions } from 'sequelize'
+import sequelize from '../Database/sequelize'
+import VehicleRecord from '../Models/VehicleRecord'
+import { VehicleRecordInterface } from '../Interfaces/VehicleRecordInterface'
+import { normalizePlate } from '../Helpers/PlateHelper'
+
+export interface VehicleSearchQuery {
+  search?: string
+  enabled?: boolean
+  sort?: string
+  page?: number
+  perPage?: number
+}
+
+export interface LinkedDriver {
+  driver_id: string
+  driver_name: string
+  selectable: boolean
+}
+
+export type VehicleWithLinkedDrivers = VehicleRecordInterface & {
+  linked_drivers: LinkedDriver[]
+}
+
+const SORT_WHITELIST = ['plate', 'brand', 'created_at']
+
+class VehicleRepository {
+  async findByNormalizedPlate(plate: string): Promise<VehicleRecordInterface | null> {
+    const record = await VehicleRecord.findOne({ where: { plate: normalizePlate(plate) } })
+    return record ? this.mapVehicle(record) : null
+  }
+
+  async findOrCreateByPlate(
+    plate: string,
+    fullPayload: Partial<VehicleRecordInterface>,
+    txn?: Transaction
+  ): Promise<VehicleRecordInterface> {
+    const normalizedPlate = normalizePlate(plate)
+    // SELECT ... FOR UPDATE to prevent concurrent inserts
+    const [rows] = await sequelize.query(`SELECT * FROM vehicles WHERE plate = :plate FOR UPDATE`, {
+      replacements: { plate: normalizedPlate },
+      type: QueryTypes.SELECT,
+      transaction: txn,
+    })
+    if (rows) {
+      return rows as VehicleRecordInterface
+    }
+    const isComplete = !!(fullPayload.brand?.trim() && fullPayload.model?.trim())
+    const created = await VehicleRecord.create(
+      { ...fullPayload, plate: normalizedPlate, enabled: isComplete } as any,
+      { transaction: txn }
+    )
+    return created.get({ plain: true }) as VehicleRecordInterface
+  }
+
+  async findById(id: string): Promise<VehicleRecordInterface | null> {
+    const record = await VehicleRecord.findByPk(id)
+    return record ? this.mapVehicle(record) : null
+  }
+
+  async create(data: Partial<VehicleRecordInterface>): Promise<VehicleRecordInterface> {
+    const record = await VehicleRecord.create(data as any)
+    return this.mapVehicle(record)
+  }
+
+  async update(id: string, partial: Partial<VehicleRecordInterface>): Promise<void> {
+    await VehicleRecord.update(partial as any, { where: { id } })
+  }
+
+  async setEnabled(id: string, enabled: boolean): Promise<void> {
+    await VehicleRecord.update({ enabled } as any, { where: { id } })
+  }
+
+  async findWithLinkedDrivers(id: string): Promise<VehicleWithLinkedDrivers | null> {
+    const rows = await sequelize.query<{
+      id: string
+      plate: string
+      brand: string | null
+      model: string | null
+      color: { name: string; hex?: string } | null
+      photo_url: string | null
+      soat_exp: Date | null
+      tec_exp: Date | null
+      enabled: boolean
+      created_at: Date
+      updated_at: Date
+      driver_id: string | null
+      driver_name: string | null
+      selectable: boolean | null
+    }>(
+      `SELECT
+        v.id,
+        v.plate,
+        v.brand,
+        v.model,
+        v.color,
+        v.photo_url,
+        v.soat_exp,
+        v.tec_exp,
+        v.enabled,
+        v.created_at,
+        v.updated_at,
+        dv.driver_id,
+        dr.name AS driver_name,
+        dv.selectable
+      FROM vehicles v
+      LEFT JOIN driver_vehicles dv ON dv.vehicle_id = v.id
+      LEFT JOIN drivers dr ON dr.id = dv.driver_id
+      WHERE v.id = :id`,
+      {
+        replacements: { id },
+        type: QueryTypes.SELECT,
+      }
+    )
+
+    if (rows.length === 0) return null
+
+    const first = rows[0]
+    const vehicle: VehicleRecordInterface = {
+      id: first.id,
+      plate: first.plate,
+      brand: first.brand,
+      model: first.model,
+      color: first.color,
+      photo_url: first.photo_url,
+      soat_exp: first.soat_exp,
+      tec_exp: first.tec_exp,
+      enabled: first.enabled,
+      created_at: first.created_at,
+      updated_at: first.updated_at,
+    }
+
+    const linked_drivers: LinkedDriver[] = rows
+      .filter((row) => row.driver_id !== null)
+      .map((row) => ({
+        driver_id: row.driver_id as string,
+        driver_name: row.driver_name as string,
+        selectable: Boolean(row.selectable),
+      }))
+
+    return { ...vehicle, linked_drivers }
+  }
+
+  async search(
+    query: VehicleSearchQuery
+  ): Promise<{ vehicles: VehicleRecordInterface[]; total: number }> {
+    const page = Math.max(1, query.page ?? 1)
+    const perPage = query.perPage ?? 30
+
+    const sortRaw = query.sort ?? 'plate'
+    const descending = sortRaw.startsWith('-')
+    const sortField = descending ? sortRaw.slice(1) : sortRaw
+    if (!SORT_WHITELIST.includes(sortField)) {
+      throw new Error(`Invalid sort field: "${sortField}". Allowed: ${SORT_WHITELIST.join(', ')}`)
+    }
+    const order: any[] = [[sortField, descending ? 'DESC' : 'ASC']]
+
+    const andWhere: WhereOptions<any>[] = []
+
+    if (query.search) {
+      const searchPattern = `%${query.search}%`
+      andWhere.push({
+        [Op.or]: [
+          { plate: { [Op.iLike]: searchPattern } },
+          { brand: { [Op.iLike]: searchPattern } },
+          { model: { [Op.iLike]: searchPattern } },
+        ],
+      })
+    }
+
+    if (query.enabled !== undefined) {
+      andWhere.push({ enabled: query.enabled })
+    }
+
+    const where: WhereOptions<any> = andWhere.length > 0 ? { [Op.and]: andWhere } : {}
+
+    const { count, rows } = await VehicleRecord.findAndCountAll({
+      where,
+      order,
+      limit: perPage,
+      offset: (page - 1) * perPage,
+    })
+
+    return {
+      vehicles: rows.map((r) => this.mapVehicle(r)),
+      total: count,
+    }
+  }
+
+  private mapVehicle(record: VehicleRecord): VehicleRecordInterface {
+    const plain = record.get({ plain: true }) as any
+    return {
+      id: plain.id,
+      plate: plain.plate,
+      brand: plain.brand ?? null,
+      model: plain.model ?? null,
+      color: plain.color ?? null,
+      photo_url: plain.photo_url ?? null,
+      soat_exp: plain.soat_exp ?? null,
+      tec_exp: plain.tec_exp ?? null,
+      enabled: Boolean(plain.enabled),
+      created_at: plain.created_at,
+      updated_at: plain.updated_at,
+    }
+  }
+}
+
+export default VehicleRepository

--- a/src/Repositories/__tests__/DriverRecordRepository.spec.ts
+++ b/src/Repositories/__tests__/DriverRecordRepository.spec.ts
@@ -12,8 +12,10 @@ jest.mock('../../Services/drivers/DriverAvailability', () => ({
 
 // sequelize is imported transitively through DriverRecord's model init; mock it
 // so the test process does not attempt a real DB connection.
+// query() is also called by list() to bulk-fetch selected vehicles and active assignments.
 jest.mock('../../Database/sequelize', () => ({
   define: jest.fn(),
+  query: jest.fn().mockResolvedValue([]),
 }))
 
 // ---------------------------------------------------------------------------
@@ -54,12 +56,25 @@ function extractConditions(where: Record<symbol | string, any>): object[] {
   return where[Op.and] ?? [where]
 }
 
-/** Serialize an object to JSON, converting Symbol keys to their string representation. */
+/** Serialize an object to JSON, including Symbol keys and converting Symbol values to strings. */
 function serializeWhere(obj: object): string {
-  return JSON.stringify(obj, (_key, value) => {
-    if (typeof value === 'symbol') return value.toString()
-    return value
-  })
+  function serialize(val: any): any {
+    if (val === null || val === undefined) return val
+    if (typeof val === 'symbol') return val.toString()
+    if (Array.isArray(val)) return val.map(serialize)
+    if (typeof val === 'object') {
+      const result: Record<string, any> = {}
+      for (const key of Object.keys(val)) {
+        result[key] = serialize((val as any)[key])
+      }
+      for (const sym of Object.getOwnPropertySymbols(val)) {
+        result[sym.toString()] = serialize((val as any)[sym])
+      }
+      return result
+    }
+    return val
+  }
+  return JSON.stringify(serialize(obj))
 }
 
 // ---------------------------------------------------------------------------
@@ -203,10 +218,10 @@ describe('DriverRecordRepository.list()', () => {
     })
   })
 
-  // --- search: vehicle.plate via JSON extraction ---
+  // --- search: vehicle.plate via driver_vehicles JOIN ---
 
-  describe('search on vehicle plate (JSON extraction)', () => {
-    it('search query includes a literal SQL fragment for vehicle plate', async () => {
+  describe('search on vehicle plate (driver_vehicles JOIN)', () => {
+    it('search query includes a literal SQL subquery joining driver_vehicles and vehicles', async () => {
       ;(DriverRecord.findAndCountAll as jest.Mock).mockResolvedValue({ count: 0, rows: [] })
 
       await repository.list({ search: 'XYZ' })
@@ -215,11 +230,13 @@ describe('DriverRecordRepository.list()', () => {
       const conditions = extractConditions(callArg.where)
       const str = serializeWhere(conditions)
 
-      // The literal for vehicle plate must appear in the search clause
-      expect(str).toContain("vehicle->>'plate'")
+      // The literal for vehicle plate must use the JOIN-based subquery
+      expect(str).toContain('driver_vehicles dv')
+      expect(str).toContain('JOIN vehicles v')
+      expect(str).toContain('v.plate ILIKE :search')
     })
 
-    it('search query does NOT match arbitrary JSON keys (only plate value)', async () => {
+    it('search query does NOT use the legacy JSONB vehicle extraction', async () => {
       ;(DriverRecord.findAndCountAll as jest.Mock).mockResolvedValue({ count: 0, rows: [] })
 
       await repository.list({ search: 'XYZ' })
@@ -228,8 +245,37 @@ describe('DriverRecordRepository.list()', () => {
       const conditions = extractConditions(callArg.where)
       const str = serializeWhere(conditions)
 
-      // The clause must reference only "plate" key, not "vehicle" as a whole-column ilike
-      expect(str).not.toMatch(/"vehicle"\s*:\s*\{.*iLike/i)
+      // The old JSONB path must no longer appear
+      expect(str).not.toContain("vehicle->>'plate'")
+    })
+  })
+
+  // --- filter by needsVehicle ---
+
+  describe('filter by needsVehicle', () => {
+    it('needsVehicle=true adds a selected_vehicle_id IS NULL condition', async () => {
+      ;(DriverRecord.findAndCountAll as jest.Mock).mockResolvedValue({ count: 0, rows: [] })
+
+      await repository.list({ needsVehicle: true })
+
+      const callArg = (DriverRecord.findAndCountAll as jest.Mock).mock.calls[0][0]
+      const conditions = extractConditions(callArg.where)
+
+      // Find the literal condition by inspecting its .val property (Symbol-keyed Op.and array)
+      const literalCondition = conditions.find((c: any) => typeof c.val === 'string') as any
+      expect(literalCondition).toBeDefined()
+      expect(literalCondition.val).toContain('selected_vehicle_id')
+      expect(literalCondition.val).toContain('IS NULL')
+    })
+
+    it('needsVehicle=false does NOT add the selected_vehicle_id condition', async () => {
+      ;(DriverRecord.findAndCountAll as jest.Mock).mockResolvedValue({ count: 0, rows: [] })
+
+      await repository.list({ needsVehicle: false })
+
+      const callArg = (DriverRecord.findAndCountAll as jest.Mock).mock.calls[0][0]
+      // No filters → where is an empty object
+      expect(Object.keys(callArg.where)).toHaveLength(0)
     })
   })
 

--- a/src/Repositories/__tests__/DriverRecordRepository.spec.ts
+++ b/src/Repositories/__tests__/DriverRecordRepository.spec.ts
@@ -41,6 +41,7 @@ function makeDriverPlain(overrides: Record<string, any> = {}): Record<string, an
     enabled_at: 1_000_000,
     created_at: 900_000,
     last_connection: 800_000,
+    selected_vehicle_id: null,
     ...overrides,
   }
 }
@@ -93,7 +94,7 @@ describe('DriverRecordRepository.list()', () => {
 
   describe('defaults: no query params', () => {
     it('uses name ASC sort and perPage 30 when no params are supplied', async () => {
-      const plain = makeDriverPlain()
+      const plain = makeDriverPlain({ selected_vehicle_id: 'veh-1' })
       ;(DriverRecord.findAndCountAll as jest.Mock).mockResolvedValue({
         count: 1,
         rows: [makeDriverModel(plain)],
@@ -103,6 +104,7 @@ describe('DriverRecordRepository.list()', () => {
 
       expect(result.total).toBe(1)
       expect(result.rows).toHaveLength(1)
+      expect(result.rows[0].selected_vehicle_id).toBe('veh-1')
 
       const callArg = (DriverRecord.findAndCountAll as jest.Mock).mock.calls[0][0]
       expect(callArg.limit).toBe(30)

--- a/src/Repositories/__tests__/DriverRecordRepository.spec.ts
+++ b/src/Repositories/__tests__/DriverRecordRepository.spec.ts
@@ -108,6 +108,7 @@ describe('DriverRecordRepository.list()', () => {
       expect(callArg.limit).toBe(30)
       expect(callArg.order).toEqual([['name', 'ASC']])
     })
+
   })
 
   // --- filter by status ---

--- a/src/Repositories/__tests__/RechargeRepository.spec.ts
+++ b/src/Repositories/__tests__/RechargeRepository.spec.ts
@@ -1,0 +1,316 @@
+import RechargeRepository from '../RechargeRepository'
+import RechargeRecord from '../../Models/RechargeRecord'
+import DriverRecord from '../../Models/DriverRecord'
+
+jest.mock('../../Models/RechargeRecord', () => ({
+  findAndCountAll: jest.fn(),
+  create: jest.fn(),
+}))
+
+jest.mock('../../Models/DriverRecord', () => ({
+  findOne: jest.fn(),
+}))
+
+// sequelize is imported as a default export (`import sequelize from '...'`).
+// Using __esModule: true tells Jest to treat this as an ES module so that
+// `sequelize_1.default` in the compiled output resolves to our mock object.
+jest.mock('../../Database/sequelize', () => ({
+  __esModule: true,
+  default: { transaction: jest.fn() },
+}))
+
+// buildDriverAvailability is called inside mapDriver — provide a lightweight stub
+jest.mock('../../Services/drivers/DriverAvailability', () => ({
+  buildDriverAvailability: jest.fn(() => 'available'),
+}))
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a minimal DriverRecord-like model stub that mapDriver can handle.
+ *
+ * The `get({ plain: true })` method returns a live reference to the same object
+ * whose properties are exposed directly on the stub. This means mutations like
+ * `driver.balance = newValue` are reflected when mapDriver later calls
+ * `driver.get({ plain: true }).balance`.
+ */
+function makeDriverModel(overrides: Record<string, any> = {}) {
+  const stub: Record<string, any> = {
+    id: 'drv-1',
+    name: 'Test',
+    email: 'test@test.com',
+    password: null,
+    phone: '3001234',
+    phone2: null,
+    docType: 'CC',
+    paymentMode: 'monthly',
+    document: '12345',
+    photoUrl: null,
+    vehicle: {},
+    device: null,
+    balance: 1000,
+    enabled_at: 1000000,
+    created_at: 900000,
+    last_connection: 800000,
+    selected_vehicle_id: null,
+    ...overrides,
+    // `get` returns the stub itself so that mutations to stub.balance etc. are visible
+    get: (_opts: any) => stub,
+    save: jest.fn().mockResolvedValue(undefined),
+  }
+  return stub
+}
+
+/** Build a minimal RechargeRecord-like model stub that mapRecharge can handle. */
+function makeRechargeModel(overrides: Record<string, any> = {}) {
+  const plain = {
+    id: 'rch-1',
+    driverId: 'drv-1',
+    amount: 500,
+    balanceBefore: 1000,
+    balanceAfter: 1500,
+    createdByUid: 'uid-admin',
+    createdByName: 'Admin',
+    note: null,
+    created_at: 1700000000,
+    ...overrides,
+  }
+  return { get: ({ plain: _p }: any) => plain }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('RechargeRepository.create()', () => {
+  let repository: RechargeRepository
+  let mockTxn: { commit: jest.Mock; rollback: jest.Mock }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    repository = new RechargeRepository()
+
+    mockTxn = {
+      commit: jest.fn().mockResolvedValue(undefined),
+      rollback: jest.fn().mockResolvedValue(undefined),
+    }
+
+    const sequelizeMock = require('../../Database/sequelize')
+    sequelizeMock.default.transaction.mockResolvedValue(mockTxn)
+  })
+
+  describe('positive recharge', () => {
+    it('creates a recharge record and returns driver with balanceAfter = before + amount', async () => {
+      const driver = makeDriverModel({ balance: 1000, paymentMode: 'monthly' })
+      ;(DriverRecord.findOne as jest.Mock).mockResolvedValue(driver)
+
+      const rechargeModel = makeRechargeModel({
+        amount: 500,
+        balanceBefore: 1000,
+        balanceAfter: 1500,
+      })
+      ;(RechargeRecord.create as jest.Mock).mockResolvedValue(rechargeModel)
+
+      const result = await repository.create({
+        driverId: 'drv-1',
+        amount: 500,
+        createdBy: { uid: 'uid-admin', name: 'Admin' },
+      })
+
+      expect(result.recharge.balanceBefore).toBe(1000)
+      expect(result.recharge.balanceAfter).toBe(1500)
+      expect(result.recharge.amount).toBe(500)
+      expect(result.driver.balance).toBe(1500)
+      expect(mockTxn.commit).toHaveBeenCalledTimes(1)
+      expect(mockTxn.rollback).not.toHaveBeenCalled()
+    })
+
+    it('passes the transaction to DriverRecord.findOne and RechargeRecord.create', async () => {
+      const driver = makeDriverModel({ balance: 200 })
+      ;(DriverRecord.findOne as jest.Mock).mockResolvedValue(driver)
+
+      const rechargeModel = makeRechargeModel({ amount: 100, balanceBefore: 200, balanceAfter: 300 })
+      ;(RechargeRecord.create as jest.Mock).mockResolvedValue(rechargeModel)
+
+      await repository.create({
+        driverId: 'drv-1',
+        amount: 100,
+        createdBy: { uid: 'uid-1', name: 'Operator' },
+      })
+
+      const findOneCall = (DriverRecord.findOne as jest.Mock).mock.calls[0][0]
+      expect(findOneCall.transaction).toBe(mockTxn)
+      expect(findOneCall.lock).toBe(true)
+
+      const createCall = (RechargeRecord.create as jest.Mock).mock.calls[0][1]
+      expect(createCall.transaction).toBe(mockTxn)
+    })
+  })
+
+  describe('negative adjustment', () => {
+    it('amount is negative — still creates record correctly', async () => {
+      const driver = makeDriverModel({ balance: 1000, paymentMode: 'monthly' })
+      ;(DriverRecord.findOne as jest.Mock).mockResolvedValue(driver)
+
+      const rechargeModel = makeRechargeModel({
+        amount: -200,
+        balanceBefore: 1000,
+        balanceAfter: 800,
+      })
+      ;(RechargeRecord.create as jest.Mock).mockResolvedValue(rechargeModel)
+
+      const result = await repository.create({
+        driverId: 'drv-1',
+        amount: -200,
+        createdBy: { uid: 'uid-admin', name: 'Admin' },
+      })
+
+      expect(result.recharge.amount).toBe(-200)
+      expect(result.recharge.balanceAfter).toBe(800)
+      expect(RechargeRecord.create).toHaveBeenCalledTimes(1)
+      expect(mockTxn.commit).toHaveBeenCalledTimes(1)
+    })
+
+    it('percentage driver with balanceAfter <= 0 does not throw and commits', async () => {
+      const driver = makeDriverModel({ balance: 100, paymentMode: 'percentage', enabled_at: 1000000 })
+      ;(DriverRecord.findOne as jest.Mock).mockResolvedValue(driver)
+
+      const rechargeModel = makeRechargeModel({
+        amount: -200,
+        balanceBefore: 100,
+        balanceAfter: -100,
+      })
+      ;(RechargeRecord.create as jest.Mock).mockResolvedValue(rechargeModel)
+
+      const result = await repository.create({
+        driverId: 'drv-1',
+        amount: -200,
+        createdBy: { uid: 'uid-admin', name: 'Admin' },
+      })
+
+      expect(result.recharge.balanceAfter).toBe(-100)
+      expect(mockTxn.commit).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('unknown driver', () => {
+    it('throws "Driver not found" and rolls back when driver does not exist', async () => {
+      ;(DriverRecord.findOne as jest.Mock).mockResolvedValue(null)
+
+      await expect(
+        repository.create({
+          driverId: 'unknown-id',
+          amount: 500,
+          createdBy: { uid: 'uid-admin', name: 'Admin' },
+        })
+      ).rejects.toThrow('Driver not found')
+
+      expect(mockTxn.rollback).toHaveBeenCalledTimes(1)
+      expect(RechargeRecord.create).not.toHaveBeenCalled()
+      expect(mockTxn.commit).not.toHaveBeenCalled()
+    })
+  })
+})
+
+describe('RechargeRepository.listForDriver()', () => {
+  let repository: RechargeRepository
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    repository = new RechargeRepository()
+  })
+
+  describe('empty list', () => {
+    it('returns { rows: [], total: 0 } when no records exist', async () => {
+      ;(RechargeRecord.findAndCountAll as jest.Mock).mockResolvedValue({ count: 0, rows: [] })
+
+      const result = await repository.listForDriver('drv-1')
+
+      expect(result.rows).toEqual([])
+      expect(result.total).toBe(0)
+    })
+  })
+
+  describe('list returns rows', () => {
+    it('returns results ordered newest-first (created_at DESC)', async () => {
+      const olderRecharge = makeRechargeModel({ id: 'rch-1', created_at: 1700000000 })
+      const newerRecharge = makeRechargeModel({ id: 'rch-2', created_at: 1700000100 })
+
+      ;(RechargeRecord.findAndCountAll as jest.Mock).mockResolvedValue({
+        count: 2,
+        rows: [newerRecharge, olderRecharge],
+      })
+
+      const result = await repository.listForDriver('drv-1')
+
+      expect(result.total).toBe(2)
+      expect(result.rows).toHaveLength(2)
+
+      const callArg = (RechargeRecord.findAndCountAll as jest.Mock).mock.calls[0][0]
+      expect(callArg.order).toEqual([['created_at', 'DESC']])
+    })
+
+    it('maps recharge records correctly', async () => {
+      const rechargeModel = makeRechargeModel({
+        id: 'rch-42',
+        driverId: 'drv-1',
+        amount: 300,
+        balanceBefore: 700,
+        balanceAfter: 1000,
+        createdByUid: 'uid-xyz',
+        createdByName: 'Operator X',
+        note: 'Top-up',
+        created_at: 1700000999,
+      })
+
+      ;(RechargeRecord.findAndCountAll as jest.Mock).mockResolvedValue({
+        count: 1,
+        rows: [rechargeModel],
+      })
+
+      const result = await repository.listForDriver('drv-1')
+
+      expect(result.rows[0]).toEqual({
+        id: 'rch-42',
+        driverId: 'drv-1',
+        amount: 300,
+        balanceBefore: 700,
+        balanceAfter: 1000,
+        createdByUid: 'uid-xyz',
+        createdByName: 'Operator X',
+        note: 'Top-up',
+        created_at: 1700000999,
+      })
+    })
+
+    it('filters by driverId', async () => {
+      ;(RechargeRecord.findAndCountAll as jest.Mock).mockResolvedValue({ count: 0, rows: [] })
+
+      await repository.listForDriver('drv-specific')
+
+      const callArg = (RechargeRecord.findAndCountAll as jest.Mock).mock.calls[0][0]
+      expect(callArg.where).toEqual({ driverId: 'drv-specific' })
+    })
+
+    it('uses default perPage of 20 and page 1 when omitted', async () => {
+      ;(RechargeRecord.findAndCountAll as jest.Mock).mockResolvedValue({ count: 0, rows: [] })
+
+      await repository.listForDriver('drv-1')
+
+      const callArg = (RechargeRecord.findAndCountAll as jest.Mock).mock.calls[0][0]
+      expect(callArg.limit).toBe(20)
+      expect(callArg.offset).toBe(0)
+    })
+
+    it('applies custom page and perPage', async () => {
+      ;(RechargeRecord.findAndCountAll as jest.Mock).mockResolvedValue({ count: 0, rows: [] })
+
+      await repository.listForDriver('drv-1', { page: 3, perPage: 10 })
+
+      const callArg = (RechargeRecord.findAndCountAll as jest.Mock).mock.calls[0][0]
+      expect(callArg.limit).toBe(10)
+      expect(callArg.offset).toBe(20) // (3 - 1) * 10
+    })
+  })
+})

--- a/src/Services/chatBot/Messages.ts
+++ b/src/Services/chatBot/Messages.ts
@@ -1,4 +1,3 @@
-import Vehicle from '../../Models/Vehicle'
 import MessageHelper from '../../Helpers/MessageHelper'
 import { Locale } from '../../Helpers/Locale'
 import { PlaceOption } from '../../Interfaces/PlaceOption'
@@ -6,6 +5,11 @@ import { Store } from '../store/Store'
 import { MessagesEnum } from './MessagesEnum'
 import { getPlaceholders, Placeholders, replacePlaceholders } from './Placeholders'
 import { ChatBotMessage } from '../../Types/ChatBotMessage'
+
+export interface VehicleSnapshot {
+  plate: string
+  color: { name: string; hex?: string } | null
+}
 
 function getStore(): Store {
   return Store.getInstance()
@@ -60,10 +64,10 @@ export const sendPlaceOptions = async (
   return getSingleMessage(MessagesEnum.DEFAULT_MESSAGE)
 }
 
-export const serviceAssigned = (vehicle: Vehicle): ChatBotMessage => {
+export const serviceAssigned = (vehicle: VehicleSnapshot): ChatBotMessage => {
   const placeholdersMap = getPlaceholders()
   placeholdersMap.set(Placeholders.PLATE, MessageHelper.truncatePlate(vehicle.plate))
-  placeholdersMap.set(Placeholders.COLOR, locale.__('colors.' + vehicle.color.name))
+  placeholdersMap.set(Placeholders.COLOR, locale.__('colors.' + (vehicle.color?.name ?? '')))
   const store = getStore()
   const message = store.findMessageById(MessagesEnum.SERVICE_ASSIGNED)
   return replacePlaceholders(message, placeholdersMap)

--- a/src/Services/chatBot/__tests__/Messages.spec.ts
+++ b/src/Services/chatBot/__tests__/Messages.spec.ts
@@ -1,0 +1,80 @@
+jest.mock('../../../Helpers/Locale', () => ({
+  Locale: {
+    getInstance: jest.fn().mockReturnValue({
+      __: (key: string) => key,
+    }),
+  },
+}))
+
+jest.mock('../../../Services/store/Store', () => ({
+  Store: {
+    getInstance: jest.fn().mockReturnValue({
+      findMessageById: jest.fn().mockImplementation(() => ({
+        id: 'service_assigned',
+        name: 'service_assigned',
+        message: 'Tu conductor llega en un movil placa [[PLATE]], color [[COLOR]]',
+        enabled: true,
+        description: '',
+        interactive: null,
+      })),
+    }),
+  },
+}))
+
+import { serviceAssigned, VehicleSnapshot } from '../Messages'
+
+describe('Messages.serviceAssigned — frozen vehicle snapshot', () => {
+  it('uses the plate from the frozen snapshot, not from a swapped vehicle', () => {
+    const frozenSnapshot: VehicleSnapshot = {
+      plate: 'ABC123',
+      color: { name: 'rojo' },
+    }
+
+    const msg = serviceAssigned(frozenSnapshot)
+
+    expect(msg.message).toContain('123')
+    expect(msg.message).not.toContain('XYZ')
+  })
+
+  it('produces different message when given the swapped vehicle plate', () => {
+    const swappedVehicle: VehicleSnapshot = {
+      plate: 'XYZ789',
+      color: { name: 'azul' },
+    }
+
+    const msg = serviceAssigned(swappedVehicle)
+
+    expect(msg.message).toContain('789')
+    expect(msg.message).not.toContain('ABC')
+  })
+
+  it('mid-shift swap: frozen snapshot plate differs from new plate and message preserves frozen plate', () => {
+    const frozenPlate = 'ABC123'
+    const swappedPlate = 'XYZ789'
+
+    const frozenSnapshot: VehicleSnapshot = { plate: frozenPlate, color: { name: 'rojo' } }
+    const swappedSnapshot: VehicleSnapshot = { plate: swappedPlate, color: { name: 'azul' } }
+
+    const msgFromFrozen = serviceAssigned(frozenSnapshot)
+    const msgFromSwapped = serviceAssigned(swappedSnapshot)
+
+    // The message built from the frozen snapshot should contain the frozen plate suffix
+    expect(msgFromFrozen.message).toContain('123')
+    // The message built from the swapped snapshot should contain the swapped plate suffix
+    expect(msgFromSwapped.message).toContain('789')
+    // They must differ — proving the function reads exactly what is passed (the snapshot),
+    // not some live driver state
+    expect(msgFromFrozen.message).not.toBe(msgFromSwapped.message)
+  })
+
+  it('handles null color gracefully without throwing', () => {
+    const snapshotWithNullColor: VehicleSnapshot = {
+      plate: 'DEF456',
+      color: null,
+    }
+
+    expect(() => serviceAssigned(snapshotWithNullColor)).not.toThrow()
+    const msg = serviceAssigned(snapshotWithNullColor)
+    expect(msg.message).toContain('456')
+  })
+})

--- a/src/Services/drivers/AutoPromoteVehicle.ts
+++ b/src/Services/drivers/AutoPromoteVehicle.ts
@@ -1,0 +1,32 @@
+import { Transaction } from 'sequelize'
+import DriverVehicleRepository from '../../Repositories/DriverVehicleRepository'
+import DriverRecord from '../../Models/DriverRecord'
+
+const driverVehicleRepo = new DriverVehicleRepository()
+
+/**
+ * Picks the most recent eligible link (selectable=true, vehicle.enabled=true)
+ * and updates drivers.selected_vehicle_id accordingly.
+ * If no eligible link exists, sets selected_vehicle_id to NULL.
+ */
+export async function autoPromoteSelectedVehicle(
+  driverId: string,
+  txn?: Transaction
+): Promise<void> {
+  const eligible = await driverVehicleRepo.findMostRecentEligible(driverId)
+  const newVehicleId = eligible ? eligible.vehicle_id : null
+
+  await DriverRecord.update({ selected_vehicle_id: newVehicleId } as any, {
+    where: { id: driverId },
+    transaction: txn,
+  })
+
+  console.log(
+    JSON.stringify({
+      metric: 'auto_promote',
+      driverId,
+      outcome: newVehicleId ? 'promoted' : 'cleared',
+      vehicleId: newVehicleId ?? null,
+    })
+  )
+}

--- a/src/Services/drivers/ForceDisconnect.ts
+++ b/src/Services/drivers/ForceDisconnect.ts
@@ -1,0 +1,29 @@
+import ActiveVehicleAssignmentRepository from '../../Repositories/ActiveVehicleAssignmentRepository'
+import DriverTokenRecordRepository from '../../Repositories/DriverTokenRecordRepository'
+import DatabaseService from '../firebase/Database'
+import FCM from '../firebase/FCM'
+
+const driverTokenRepo = new DriverTokenRecordRepository()
+
+/**
+ * Forcibly disconnects a driver from their active vehicle assignment:
+ * 1. Deletes the active_vehicle_assignments row for the driver.
+ * 2. Removes the driver from the RTDB online_drivers node.
+ * 3. Sends a data-only FCM message with type=force_disconnect and the given reason.
+ */
+export async function forceDisconnect(driverId: string, reason: string): Promise<void> {
+  await ActiveVehicleAssignmentRepository.releaseByDriver(driverId)
+
+  await DatabaseService.dbConnectedDrivers().child(driverId).remove()
+
+  const tokenRecord = await driverTokenRepo.findByDriverId(driverId)
+  if (tokenRecord?.token) {
+    await FCM.sendNotificationTo(tokenRecord.token, {
+      title: '',
+      body: '',
+      data: { type: 'force_disconnect', reason },
+    })
+  }
+
+  console.log(JSON.stringify({ metric: 'force_disconnect', driverId, reason }))
+}

--- a/src/Services/serviceHistory/ServiceHistoryMigrationService.ts
+++ b/src/Services/serviceHistory/ServiceHistoryMigrationService.ts
@@ -8,6 +8,7 @@ import ServiceHistoryRecord from '../../Models/ServiceHistoryRecord'
 import ServiceMetricsDailyRepository from '../../Repositories/ServiceMetricsDailyRepository'
 import ServiceRepository from '../../Repositories/ServiceRepository'
 import ChatIdHelper from '../../Helpers/ChatIdHelper'
+import VehicleRepository from '../../Repositories/VehicleRepository'
 
 dayjs.extend(utc)
 dayjs.extend(timezone)
@@ -152,7 +153,13 @@ class ServiceHistoryMigrationService {
   }
 
   async upsertHistoryRecord(service: ServiceInterface): Promise<void> {
-    await ServiceHistoryRecord.upsert(this.buildHistoryPayload(service))
+    const payload: any = this.buildHistoryPayload(service)
+    if (service.vehicle?.plate && !payload.vehicle_id) {
+      const vehicleRepo = new VehicleRepository()
+      const vehicle = await vehicleRepo.findByNormalizedPlate(service.vehicle.plate)
+      if (vehicle) payload.vehicle_id = vehicle.id
+    }
+    await ServiceHistoryRecord.upsert(payload)
   }
 
   private buildHistoryPayload(
@@ -178,6 +185,7 @@ class ServiceHistoryMigrationService {
       assigned_by: persist.assigned_by ?? null,
       canceled_by: persist.canceled_by ?? null,
       terminated_by: persist.terminated_by ?? null,
+      vehicle_id: persist.vehicle_id ?? null,
     }
   }
 }

--- a/src/Services/whatsapp/WhatsAppClient.ts
+++ b/src/Services/whatsapp/WhatsAppClient.ts
@@ -34,6 +34,8 @@ import InboundMessageDedupCache from './policies/InboundMessageDedupCache'
 import IgnoredInboundMessageAuditRepository from '../../Repositories/IgnoredInboundMessageAuditRepository'
 import ChatIdHelper from '../../Helpers/ChatIdHelper'
 import MessageRepository from '../../Repositories/MessageRepository'
+import DatabaseService from '../firebase/Database'
+import { VehicleSnapshot } from '../chatBot/Messages'
 
 export class WhatsAppClient {
   public client: WPClientInterface
@@ -372,18 +374,46 @@ export class WhatsAppClient {
   serviceAssigned = async (snapshot: DataSnapshot): Promise<void> => {
     const notification: WpNotificationType = snapshot.val()
     if (notification.driver_id != null && notification.wp_client_id == this.wpClient.id) {
-      const driver = this.store.findDriverById(notification.driver_id)
-      const msg = Messages.serviceAssigned(driver.vehicle)
+      const serviceId = snapshot.key ?? ''
+      const vehicle = await this.readServiceVehicleSnapshot(serviceId)
+      const msg = Messages.serviceAssigned(vehicle)
       if (msg.enabled) {
         await this.sendMessage(notification.client_id, msg).then(() => {
-          WpNotificationRepository.deleteNotification('assigned', snapshot.key ?? '')
+          WpNotificationRepository.deleteNotification('assigned', serviceId)
         })
       } else {
-        await WpNotificationRepository.deleteNotification('assigned', snapshot.key ?? '')
+        await WpNotificationRepository.deleteNotification('assigned', serviceId)
       }
     } else {
       console.error('can not send message cause driver id is not set', notification, this.wpClient)
     }
+  }
+
+  private readServiceVehicleSnapshot = async (serviceId: string): Promise<VehicleSnapshot> => {
+    try {
+      const vehicleSnap = await DatabaseService.dbServices().child(serviceId).child('vehicle').get()
+      if (vehicleSnap.exists()) {
+        const v = vehicleSnap.val() as {
+          plate?: string
+          color?: { name: string; hex?: string } | null
+        }
+        if (v?.plate) {
+          return { plate: v.plate, color: v.color ?? null }
+        }
+      }
+    } catch (e) {
+      console.error('readServiceVehicleSnapshot error', serviceId, e)
+    }
+    // fallback: read from driver in store (pre-snapshot-era services or missing snapshot)
+    const serviceSnap = await DatabaseService.dbServices().child(serviceId).get()
+    const driverId: string | null = serviceSnap.exists()
+      ? (serviceSnap.val()?.driver_id ?? null)
+      : null
+    if (driverId) {
+      const driver = this.store.findDriverById(driverId)
+      return { plate: driver.vehicle?.plate ?? '', color: driver.vehicle?.color ?? null }
+    }
+    return { plate: '', color: null }
   }
 
   driverArrived = async (snapshot: DataSnapshot): Promise<void> => {
@@ -496,12 +526,21 @@ export class WhatsAppClient {
 
     switch (service.status) {
       case Service.STATUS_IN_PROGRESS:
-        const driver = this.store.findDriverById(service.driver_id!!)
         if (!service.metadata) {
           await session.setStatus(Session.STATUS_SERVICE_IN_PROGRESS)
           if (!session.notifications.assigned) {
             await session.setNotification(NotificationType.assigned)
-            msg = Messages.serviceAssigned(driver.vehicle)
+            const snapshotVehicle = (snapshot.val() as any)?.vehicle as VehicleSnapshot | undefined
+            const vehicleForMsg: VehicleSnapshot = snapshotVehicle?.plate
+              ? snapshotVehicle
+              : (() => {
+                  const driver = this.store.findDriverById(service.driver_id!!)
+                  return {
+                    plate: driver.vehicle?.plate ?? '',
+                    color: driver.vehicle?.color ?? null,
+                  }
+                })()
+            msg = Messages.serviceAssigned(vehicleForMsg)
             message = msg
             mustSend = msg.enabled && !this.wpClient.wpNotifications
           }

--- a/src/app.ts
+++ b/src/app.ts
@@ -36,10 +36,12 @@ import UsersController from './Api/Controllers/Users/UsersController'
 import DriversController, {
   PublicDriversController,
 } from './Api/Controllers/Drivers/DriversController'
+import VehiclesController from './Api/Controllers/Vehicles/VehiclesController'
 import DriverAppController from './Api/Controllers/Drivers/DriverAppController'
 import ServiceHistoryController from './Api/Controllers/Services/ServiceHistoryController'
 import MetricsController from './Api/Controllers/Metrics/MetricsController'
 import ServiceHistoryInternalController from './Api/Controllers/Internal/ServiceHistoryInternalController'
+import DriversInternalController from './Api/Controllers/Internal/DriversInternalController'
 import BillingController from './Api/Controllers/Billing/BillingController'
 import type { CorsOptions } from 'cors'
 import ChatRealtimeGateway from './Services/whatsapp/ChatRealtimeGateway'
@@ -124,11 +126,13 @@ app.use('/public/master-data', PublicMasterDataController)
 app.use('/users', UsersController)
 app.use('/drivers', DriversController)
 app.use('/public/drivers', PublicDriversController)
+app.use('/vehicles', VehiclesController)
 app.use('/driver-app', DriverAppController)
 app.use('/services', ServiceHistoryController)
 app.use('/metrics', MetricsController)
 app.use('/billing', BillingController)
 app.use('/internal/service-history', ServiceHistoryInternalController)
+app.use('/internal/drivers', DriversInternalController)
 
 const serverSSL: HTTPSServer = https.createServer(SSL.getCredentials(config.APP_DOMAIN), app)
 const server: HTTPServer = http.createServer(app)


### PR DESCRIPTION
## What changed
- adds normalized vehicle table migration and driver roster/connect flow support
- tightens vehicle completeness validation and lookup handling for extracted vehicles
- bumps the API version to 2.0.5 and prepares the changelog entry

## Why
The admin and driver clients need a normalized vehicle backend flow instead of the legacy embedded vehicle payloads.

## Impact
Vehicle lookup, linking, validation, and roster operations are served consistently from the API and version metadata is updated for release tracking.

## Validation
- `docker compose exec api sh -lc "npm run build"`
